### PR TITLE
Remove Liberdus token validation and related configurations from CreateOrder component and debug settings

### DIFF
--- a/index.html
+++ b/index.html
@@ -585,10 +585,6 @@
                 <input type="checkbox" data-debug="PRICING_DEFAULT_TO_ONE" />
                 <span>Default Missing Prices to 1</span>
               </label>
-              <label class="debug-option">
-                <input type="checkbox" data-debug="LIBERDUS_VALIDATION" />
-                <span>WhaleSwap Token Validation</span>
-              </label>
             </div>
           </div>
           <div class="debug-footer">

--- a/js/components/CreateOrder.js
+++ b/js/components/CreateOrder.js
@@ -14,11 +14,6 @@ import { handleTransactionError } from '../utils/ui.js';
 import { getExplorerUrl } from '../utils/orderUtils.js';
 
 export class CreateOrder extends BaseComponent {
-    // Liberdus token addresses by network chainId (decimal, not hex)
-    static LIBERDUS_ADDRESSES = {
-        '137': '0x693ed886545970f0a3adf8c59af5ccdb6ddf0a76' // Polygon Mainnet
-    };
-    
     constructor() {
         super('create-order');
         this.contract = null;
@@ -621,18 +616,6 @@ export class CreateOrder extends BaseComponent {
             if (this.sellToken.address.toLowerCase() === this.buyToken.address.toLowerCase()) {
                 this.showError(`Cannot create an order with the same token (${this.sellToken.symbol}) for both buy and sell. Please select different tokens.`);
                 return;
-            }
-
-            // Validate that one of the tokens must be Liberdus (LIB) - controlled by debug flag
-            if (window.DEBUG_CONFIG?.LIBERDUS_VALIDATION) {
-                const sellTokenIsLiberdus = this.isLiberdusToken(this.sellToken.address);
-                const buyTokenIsLiberdus = this.isLiberdusToken(this.buyToken.address);
-                
-                if (!sellTokenIsLiberdus && !buyTokenIsLiberdus) {
-                    this.debug('Liberdus validation failed');
-                    this.showError('One of the tokens must be Liberdus (LIB). Please select Liberdus as either the buy or sell token.');
-                    return;
-                }
             }
 
             // Validate that both tokens are allowed in the contract
@@ -1489,46 +1472,6 @@ export class CreateOrder extends BaseComponent {
         }
     }
 
-    /**
-     * Helper method to check if a token is Liberdus
-     * Uses network-aware address lookup based on current chainId
-     * @param {string} tokenAddress - Token address to check
-     * @returns {boolean} True if the token is Liberdus on the current network
-     */
-    isLiberdusToken(tokenAddress) {
-        try {
-            // Get current chainId from walletManager
-            const chainId = walletManager?.chainId;
-            if (!chainId) {
-                this.debug('No chainId available, cannot verify Liberdus token');
-                return false;
-            }
-            
-            // Convert hex chainId to decimal string for lookup
-            const chainIdDecimal = typeof chainId === 'string' && chainId.startsWith('0x')
-                ? parseInt(chainId, 16).toString()
-                : chainId.toString();
-            
-            // Look up Liberdus address for current network
-            const liberdusAddress = CreateOrder.LIBERDUS_ADDRESSES[chainIdDecimal];
-            
-            if (!liberdusAddress) {
-                this.debug(`No Liberdus address configured for chainId: ${chainIdDecimal}`);
-                return false;
-            }
-            
-            const isLiberdus = tokenAddress.toLowerCase() === liberdusAddress.toLowerCase();
-            if (isLiberdus) {
-                this.debug(`Token ${tokenAddress} is Liberdus on chain ${chainIdDecimal}`);
-            }
-            
-            return isLiberdus;
-        } catch (error) {
-            this.debug('Error checking if token is Liberdus:', error);
-            return false;
-        }
-    }
-
     normalizeTokenDisplay(token) {
         return token;
     }
@@ -1718,19 +1661,6 @@ export class CreateOrder extends BaseComponent {
             handleTransactionError(error, this, 'token approval');
             return false;
         }
-    }
-
-    // Helper method to check if Liberdus validation is enabled
-    isLiberdusValidationEnabled() {
-        if (window.DEBUG_CONFIG?.LIBERDUS_VALIDATION !== true) {
-            return false;
-        }
-
-        const activeChainId = walletManager?.chainId
-            ? Number.parseInt(walletManager.chainId, 16).toString()
-            : null;
-
-        return !!(activeChainId && CreateOrder.LIBERDUS_ADDRESSES[activeChainId]);
     }
 
     // Add new helper method for user-friendly error messages

--- a/js/config/debug.js
+++ b/js/config/debug.js
@@ -14,7 +14,6 @@ export const DEBUG_CONFIG = {
     TOKEN_ICON_SERVICE: false, // Add token icon service debugging
     TOAST: false, // Enable toast debugging for testing
     PRICING_DEFAULT_TO_ONE: false, // Default missing prices to 1 for testing, false for production
-    LIBERDUS_VALIDATION: true, // Enable frontend Liberdus token validation
     ADMIN_BYPASS_OWNER_CHECK: false, // Temporary: bypass owner gating for Admin tab access
     // Add more specific flags as needed
 };


### PR DESCRIPTION
This simplifies the order creation process by eliminating unnecessary checks and streamlining the codebase.