### PR TITLE
Align Network Toasts With Wallet Add/Switch Error Semantics

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -23,6 +23,7 @@ import { Admin } from './components/Admin.js';
 import { versionService } from './services/VersionService.js';
 import { createAppContext, setGlobalContext } from './services/AppContext.js';
 import { hasAnyClaimables } from './utils/claims.js';
+import { isUserRejection } from './utils/ui.js';
 
 class App {
 	constructor() {
@@ -1544,10 +1545,8 @@ function isNetworkAddRequiredError(error) {
 
 function isWalletUserRejectedError(error) {
 	if (!error) return false;
-	if (error.code === 4001 || error?.originalSwitchError?.code === 4001) return true;
-
-	const message = String(error.message || '').toLowerCase();
-	return message.includes('user rejected') || message.includes('rejected the request');
+	if (isUserRejection(error)) return true;
+	return Boolean(error?.originalSwitchError) && isUserRejection(error.originalSwitchError);
 }
 
 function setNetworkSwitchInProgress(isInProgress) {


### PR DESCRIPTION
- Refactored network switch error handling to classify failures by explicit wallet error signals instead of inferred chain mismatch.
- Updated add-required toast copy to a single consistent message: `Wallet does not have <network> added. Press Add Network.`
- Added dedicated handling for user-cancelled wallet requests (`4001`) with a neutral toast: `Wallet request was cancelled.`
- Removed misleading “wrong network” warning toasts from `accountsChanged` and `chainChanged` mismatch paths.
- Simplified `switchWalletToNetworkWithReload` and `handleNetworkSwitchFailure` by removing obsolete `walletNetworkForMessage` parameter flow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to wallet network-switch error classification and user-facing toast copy; main risk is confusing UX or missed edge cases in error-code detection.
> 
> **Overview**
> Aligns wallet network-switch toasts with explicit wallet error semantics: uses a consistent “add network” message for `4902`-style errors and adds a dedicated user-cancelled (`4001`) toast.
> 
> Simplifies the network-switch flow by removing the `walletNetworkForMessage` parameter and eliminating “wrong network” warning toasts during `accountsChanged`/`chainChanged` mismatch handling (tabs are hidden without a toast). Also updates repo hygiene by ignoring `docs/` and `.vscode/` while removing the tracked `.vscode/settings.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e7bbbadf9888cf326d5460148e9172633099b97. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->