### PR TITLE
Refactor debug settings handling

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1068,37 +1068,6 @@ class App {
 		this.initializeTabRail();
 	}
 
-	initializeDebugPanel() {
-		// Show debug panel with keyboard shortcut (Ctrl+Shift+D)
-		document.addEventListener('keydown', (e) => {
-			if (e.ctrlKey && e.shiftKey && e.key === 'D') {
-				const panel = document.querySelector('.debug-panel');
-				if (panel) {
-					panel.style.display = panel.style.display === 'none' ? 'block' : 'none';
-				}
-			}
-		});
-
-		// Initialize checkboxes from localStorage
-		const savedDebug = localStorage.getItem('debug');
-		if (savedDebug) {
-			const settings = JSON.parse(savedDebug);
-			document.querySelectorAll('[data-debug]').forEach(checkbox => {
-				checkbox.checked = settings[checkbox.dataset.debug] ?? false;
-			});
-		}
-
-		// Handle apply button
-		document.getElementById('applyDebug')?.addEventListener('click', () => {
-			const settings = {};
-			document.querySelectorAll('[data-debug]').forEach(checkbox => {
-				settings[checkbox.dataset.debug] = checkbox.checked;
-			});
-			localStorage.setItem('debug', JSON.stringify(settings));
-			location.reload(); // Reload to apply new debug settings
-		});
-	}
-
 	async initializeWalletManager() {
 		try {
 			this.debug('Initializing wallet manager...');
@@ -1525,9 +1494,6 @@ window.app = new App();
 // Toast functions are now accessed via AppContext (this.ctx.showError, etc.)
 // Removed window.* assignments - all components use ctx or BaseComponent methods
 window.getToast = getToast; // Keep for external/debug access if needed
-
-// Make DEBUG_CONFIG globally available for debug panel
-window.DEBUG_CONFIG = DEBUG_CONFIG;
 
 // Initialize app when DOM is loaded
 document.addEventListener('DOMContentLoaded', async () => {

--- a/js/components/DebugPanel.js
+++ b/js/components/DebugPanel.js
@@ -1,3 +1,5 @@
+import { DEBUG_CONFIG, getStoredDebugSettings, saveDebugSettings } from '../config/debug.js';
+
 export class DebugPanel {
     constructor() {
         this.panel = document.querySelector('.debug-panel');
@@ -37,17 +39,12 @@ export class DebugPanel {
     }
 
     loadDebugSettings() {
-        const savedSettings = localStorage.getItem('debug');
-        let settings = {};
-        
-        if (savedSettings) {
-            settings = JSON.parse(savedSettings);
-        }
+        const settings = getStoredDebugSettings();
         
         this.checkboxes.forEach(checkbox => {
             const debugKey = checkbox.getAttribute('data-debug');
             // Use saved setting if available, otherwise use default from DEBUG_CONFIG
-            checkbox.checked = settings[debugKey] ?? window.DEBUG_CONFIG?.[debugKey] ?? false;
+            checkbox.checked = settings[debugKey] ?? DEBUG_CONFIG[debugKey] ?? false;
         });
     }
 
@@ -65,11 +62,11 @@ export class DebugPanel {
             settings[debugKey] = checkbox.checked;
         });
         
-        localStorage.setItem('debug', JSON.stringify(settings));
+        saveDebugSettings(settings);
         location.reload(); // Reload to apply new debug settings
     }
 
     togglePanel() {
         this.panel.style.display = this.panel.style.display === 'none' ? 'block' : 'none';
     }
-} 
+}

--- a/js/config/debug.js
+++ b/js/config/debug.js
@@ -18,12 +18,40 @@ export const DEBUG_CONFIG = {
     // Add more specific flags as needed
 };
 
-export const isDebugEnabled = (component) => {
-    // Check if debug mode is forced via localStorage
-    const localDebug = localStorage.getItem('debug');
-    if (localDebug) {
-        const debugSettings = JSON.parse(localDebug);
-        return debugSettings[component] ?? DEBUG_CONFIG[component];
+export const DEBUG_STORAGE_KEY = 'whaleswap_debug';
+
+const isPlainObject = (value) => value && typeof value === 'object' && !Array.isArray(value);
+
+const parseDebugSettings = (rawValue) => {
+    if (!rawValue || typeof rawValue !== 'string') {
+        return null;
     }
+
+    try {
+        const parsed = JSON.parse(rawValue);
+        return isPlainObject(parsed) ? parsed : null;
+    } catch (_) {
+        return null;
+    }
+};
+
+export const getStoredDebugSettings = () => {
+    return parseDebugSettings(localStorage.getItem(DEBUG_STORAGE_KEY)) || {};
+};
+
+export const saveDebugSettings = (settings) => {
+    if (!isPlainObject(settings)) {
+        return;
+    }
+
+    localStorage.setItem(DEBUG_STORAGE_KEY, JSON.stringify(settings));
+};
+
+export const isDebugEnabled = (component) => {
+    const debugSettings = getStoredDebugSettings();
+    if (Object.prototype.hasOwnProperty.call(debugSettings, component)) {
+        return debugSettings[component];
+    }
+
     return DEBUG_CONFIG[component];
 };


### PR DESCRIPTION
## Summary
- Task started from a startup issue report: Phantom wallet injection appeared to interfere with app startup when both MetaMask and Phantom were installed.
- Reported case: Tinasha had MetaMask + Phantom; disabling Phantom allowed startup.
- We could not reliably reproduce yet, and we still need to confirm Tinasha's OS/environment details.
- This PR is part 1 of 3 and keeps the debug/config cleanup isolated so wallet startup fixes can be reviewed separately.
- Move debug panel setting persistence into shared helpers in `js/config/debug.js`.
- Update `DebugPanel` to use config exports directly instead of `window.DEBUG_CONFIG`.
- Remove legacy app-level debug panel wiring and global debug config exposure.

## Problem and resolution
- Problem observed: startup instability in mixed-wallet environments (MetaMask + Phantom), with extra unrelated changes in the same working set making root-cause review harder.
- What this PR resolves: separates non-wallet debug refactors into an independent PR, reducing noise so the Phantom/MetaMask startup fixes are easier to validate in the other two PRs.

## Test plan
- [ ] Open debug panel and verify toggles initialize from saved values
- [ ] Change debug toggles, apply, reload, and confirm values persist
- [ ] Verify normal app startup remains unchanged