### PR TITLE
Harden MetaMask provider resolution and wallet requests

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1706,7 +1706,7 @@ function syncAddNetworkButtonVisibility() {
 	const walletChainId = window.app?.ctx?.getWalletChainId?.();
 	const walletNetwork = walletChainId ? getNetworkById(walletChainId) : null;
 	const shouldShow = Boolean(
-		window.ethereum
+		walletManager.hasInjectedProvider()
 		&& walletChainId
 		&& !networkSwitchInProgress
 		&& (!walletNetwork || walletNetwork.slug !== selectedSlug)
@@ -1862,8 +1862,8 @@ document.addEventListener('DOMContentLoaded', () => {
 			const selectedSlug = selectedNetworkSlug || window.app?.ctx?.getSelectedChainSlug?.() || getDefaultNetwork().slug;
 			const selectedNetwork = getNetworkBySlug(selectedSlug) || getDefaultNetwork();
 
-			if (!window.ethereum) {
-				window.app?.showWarning?.('No injected wallet detected.');
+			if (!walletManager.hasInjectedProvider()) {
+				window.app?.showWarning?.('MetaMask is required. Phantom is not supported.');
 				return;
 			}
 


### PR DESCRIPTION
## Summary
- Task started from a startup issue report: Phantom wallet injection appeared to interfere with app startup when both MetaMask and Phantom were installed.
- Reported case: Tinasha had MetaMask + Phantom; disabling Phantom allowed startup.
- We could not reliably reproduce yet, and we still need to confirm Tinasha's OS/environment details.
- This PR is part 2 of 3 and contains the core wallet-provider startup hardening.
- Add MetaMask-only injected provider resolution in `WalletManager` with explicit unsupported-provider handling.
- Route wallet RPC calls through centralized request helpers, including startup timeout guards.
- Update app-level wallet checks to use `walletManager.hasInjectedProvider()` and clearer warning copy.

## Problem and resolution
- Problem observed: injected provider ambiguity could allow Phantom-influenced startup paths, causing startup/loading issues in some user setups.
- What this PR resolves: enforces MetaMask selection, rejects unsupported injected providers for this product scope, and adds timeout-protected startup requests to avoid hanging/fragile initialization.

## Test plan
- [ ] Start app with MetaMask only and confirm normal connect/network switch behavior
- [ ] Start app with MetaMask + Phantom installed and verify MetaMask is selected and startup remains stable
- [ ] Start app with unsupported injected provider setup and confirm read-only path/warnings
- [ ] Verify startup does not hang if wallet RPC calls are slow or unresponsive