### PR TITLE
Recover wallet UI session state after partial init

### DIFF
--- a/js/utils/balanceValidation.js
+++ b/js/utils/balanceValidation.js
@@ -1,5 +1,6 @@
 import { ethers } from 'ethers';
 import { contractService } from '../services/ContractService.js';
+import { walletManager } from '../services/WalletManager.js';
 import { getTokenBalanceInfo as getTokenBalanceInfoFromTokens } from './contractTokens.js';
 import { createLogger } from '../services/LogService.js';
 
@@ -30,11 +31,9 @@ export async function validateSellBalance(tokenAddress, sellAmount, decimals = 1
         }
         
         // Check if wallet is connected
-        if (!window.ethereum || !window.ethereum.selectedAddress) {
+        if (!walletManager.getAccount?.()) {
             throw new Error('Wallet not connected');
         }
-
-        const userAddress = window.ethereum.selectedAddress;
         const provider = contractService.getProvider();
         
         if (!provider) {
@@ -97,12 +96,10 @@ export async function getTokenBalanceInfo(tokenAddress) {
             return { balance: '0', symbol: 'N/A', decimals: 18 };
         }
         
-        if (!window.ethereum || !window.ethereum.selectedAddress) {
+        if (!walletManager.getAccount?.()) {
             debug('Wallet not connected');
             return { balance: '0', symbol: 'N/A', decimals: 18 };
         }
-
-        const userAddress = window.ethereum.selectedAddress;
         const provider = contractService.getProvider();
         
         if (!provider) {
@@ -132,7 +129,7 @@ export async function getTokenBalanceInfo(tokenAddress) {
 export async function validateBalanceService() {
     try {
         // Check if wallet is connected
-        if (!window.ethereum || !window.ethereum.selectedAddress) {
+        if (!walletManager.getAccount?.()) {
             debug('Balance service validation failed: Wallet not connected');
             return false;
         }
@@ -159,7 +156,7 @@ export async function validateBalanceService() {
 export function getValidationStats() {
     return {
         serviceValid: validateBalanceService(),
-        walletConnected: !!(window.ethereum && window.ethereum.selectedAddress),
+        walletConnected: !!walletManager.getAccount?.(),
         providerAvailable: !!contractService.getProvider()
     };
 }


### PR DESCRIPTION
## Summary
- Task started from a startup issue report: Phantom wallet injection appeared to interfere with app startup when both MetaMask and Phantom were installed.
- Reported case: Tinasha had MetaMask + Phantom; disabling Phantom allowed startup.
- We could not reliably reproduce yet, and we still need to confirm Tinasha's OS/environment details.
- This PR is part 3 of 3 and is stacked on `feat/wallet-provider-hardening`.
- Add a WalletUI recovery path that probes existing wallet session state via `WalletManager` timeout-backed requests.
- Synchronize recovered account/chain state back into wallet manager and UI network badge rendering.
- Replace direct `window.ethereum.selectedAddress` checks in balance validation with `walletManager.getAccount()`.

## Problem and resolution
- Problem observed: after partial wallet init/startup issues, UI state and balance checks could remain inconsistent even when a provider session existed.
- What this PR resolves: adds a safe recovery/sync path so existing wallet sessions are restored into app state, and aligns balance validation with `walletManager` as the source of truth.

## Test plan
- [ ] Simulate partial wallet init failure and verify UI can recover existing session
- [ ] Confirm wallet/account badge updates correctly after recovery
- [ ] Verify sell balance validation behaves correctly for connected and disconnected states