### PR TITLE
Fix: Align app network with restored wallet session on hard refresh

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -581,6 +581,31 @@ class App {
 		return getNetworkBySlug(selectedSlug) || getDefaultNetwork();
 	}
 
+	alignSelectedNetworkToRestoredWallet() {
+		const requestedSlug = getChainSlugFromUrl();
+		if (requestedSlug) {
+			return false;
+		}
+
+		const walletChainId = this.ctx?.getWalletChainId?.() ?? walletManager.chainId ?? null;
+		if (!walletChainId) {
+			return false;
+		}
+
+		const walletNetwork = getNetworkById(walletChainId);
+		const selectedNetwork = this.getSelectedNetwork();
+		if (!walletNetwork || walletNetwork.slug === selectedNetwork.slug) {
+			return false;
+		}
+
+		this.debug(
+			'No chain requested in URL; aligning selected network to restored wallet chain:',
+			walletNetwork.slug
+		);
+		applySelectedNetwork(walletNetwork, { updateUrl: true });
+		return true;
+	}
+
 	isWalletOnSelectedNetwork(chainId = null) {
 		const walletChainId = chainId ?? this.ctx?.getWalletChainId?.() ?? walletManager.chainId ?? null;
 		const walletNetwork = getNetworkById(walletChainId);
@@ -692,6 +717,7 @@ class App {
 
 			this.updateGlobalLoaderText('Initializing wallet...');
 			await this.initializeWalletManager();
+			this.alignSelectedNetworkToRestoredWallet();
 			this.updateGlobalLoaderText('Initializing pricing...');
 			await this.initializePricingService();
 			this.updateGlobalLoaderText('Connecting to order feed...');


### PR DESCRIPTION
- Fixes a refresh bug where MetaMask reconnected successfully, but the app could still boot into wrong-network/read-only state and show `Add Network`.
- Root cause: on load, the app restored the wallet session first, but pricing/WebSocket/services still initialized against the default selected network unless the URL already had `?chain=...`.
- Solution: after wallet initialization, the app now checks for a restored wallet chain and, when no explicit chain is requested in the URL, aligns the selected app network to that wallet network before network-scoped services initialize.
- Preserves explicit routing behavior: if `?chain=` is present, the app continues to respect the URL-selected network.
- Result: hard refresh now restores the connected wallet into the correct connected mode on the matching chain instead of requiring a manual network add/switch flow.