### PR TITLE
Align Intro/FAQ copy with current WhaleSwap contract behavior

### DIFF
--- a/js/components/Intro.js
+++ b/js/components/Intro.js
@@ -183,7 +183,7 @@ export class Intro extends BaseComponent {
 								<ul>
 										<li>Non-refundable fee: <span class="intro-fee-full">the configured order creation fee</span></li>
 									<li>Orders expire after 7 days</li>
-									<li>You can cancel any active order until it is cleaned up</li>
+									<li>Cancel before cleanup</li>
 									<li>Cleanup after 14 days</li>
 							</ul>
 						</div>


### PR DESCRIPTION
## Summary
- refresh Intro lead copy to: "WhaleSwap makes peer-to-peer token trading simple with decentralized escrow."
- update Connect Wallet guidance to use network-agnostic gas-token wording (BNB/POL/ETH examples)
- update Fees & Cancellation bullet to concise, contract-accurate wording: "Cancel before cleanup"
- clarify Cancelling Orders and Order Cleanup FAQ entries to reflect Claim-balance credits and withdraw flow
- clarify cleanup wording to avoid "no fees" ambiguity (no protocol trading fee)
- update Order Status FAQ to match on-chain statuses (Active, Filled, Canceled) and explain expiry as time-based
- remove outdated Order Recycling FAQ
<img width="1159" height="543" alt="image" src="https://github.com/user-attachments/assets/db343f5f-70e3-4af8-974a-f2f3f2d6f324" />

<img width="1134" height="824" alt="image" src="https://github.com/user-attachments/assets/0d00757a-13f3-4992-9ec0-0b78d986b0e3" />
