### PR TITLE
Handle ContractDisabled event in Create Order and Contract Params

### DIFF
--- a/js/components/ContractParams.js
+++ b/js/components/ContractParams.js
@@ -21,6 +21,7 @@ export class ContractParams extends BaseComponent {
         this.RECONNECT_TIMEOUT_MS = 45000;
         this.RECONNECT_RETRY_LIMIT = 1;
         this.feeConfigUpdatedHandler = null;
+        this.contractDisabledHandler = null;
     }
 
     setupFeeConfigSubscription(ws) {
@@ -49,6 +50,46 @@ export class ContractParams extends BaseComponent {
         ws.subscribe('FeeConfigUpdated', this.feeConfigUpdatedHandler);
     }
 
+    setupContractDisabledSubscription(ws) {
+        if (!ws?.subscribe) {
+            return;
+        }
+
+        if (!this.contractDisabledHandler) {
+            this.contractDisabledHandler = () => {
+                this.debug('ContractDisabled received, updating contract state display');
+                this.applyContractDisabledState();
+            };
+        }
+
+        if (ws.unsubscribe) {
+            ws.unsubscribe('ContractDisabled', this.contractDisabledHandler);
+        }
+        ws.subscribe('ContractDisabled', this.contractDisabledHandler);
+    }
+
+    applyContractDisabledState() {
+        if (!this.cachedParams) {
+            if (this.container?.classList?.contains('active') && !this.isInitializing) {
+                this.initialize().catch((error) => {
+                    this.debug('Failed to refresh contract parameters after ContractDisabled:', error);
+                });
+            }
+            return;
+        }
+
+        this.cachedParams = {
+            ...this.cachedParams,
+            isDisabled: true
+        };
+        this.lastFetchTime = Date.now();
+
+        const paramsContainer = this.container?.querySelector?.('.params-container');
+        if (paramsContainer) {
+            paramsContainer.innerHTML = this.generateParametersHTML(this.cachedParams);
+        }
+    }
+
     async initialize(readOnlyMode = true) {
         if (this.isInitializing) {
             this.debug('Already initializing, skipping...');
@@ -60,6 +101,7 @@ export class ContractParams extends BaseComponent {
         try {
             const ws = this.ctx.getWebSocket();
             this.setupFeeConfigSubscription(ws);
+            this.setupContractDisabledSubscription(ws);
 
             const now = Date.now();
             if (this.cachedParams && (now - this.lastFetchTime) < this.CACHE_DURATION) {
@@ -491,6 +533,9 @@ export class ContractParams extends BaseComponent {
         const ws = this.ctx.getWebSocket();
         if (ws?.unsubscribe && this.feeConfigUpdatedHandler) {
             ws.unsubscribe('FeeConfigUpdated', this.feeConfigUpdatedHandler);
+        }
+        if (ws?.unsubscribe && this.contractDisabledHandler) {
+            ws.unsubscribe('ContractDisabled', this.contractDisabledHandler);
         }
         // Don't clear the cache on cleanup
         this.isInitialized = false;

--- a/js/components/CreateOrder.js
+++ b/js/components/CreateOrder.js
@@ -30,6 +30,7 @@ export class CreateOrder extends BaseComponent {
         this.allowedTokensLoadPromise = null;
         this.feeLoadPromise = null;
         this.feeConfigUpdatedHandler = null;
+        this.contractDisabledHandler = null;
         this.pendingFeeConfigRefresh = false;
         this.sellToken = null;
         this.buyToken = null;
@@ -261,6 +262,7 @@ export class CreateOrder extends BaseComponent {
             
             // Wait for contract to be ready
             await this.waitForContract();
+            this.subscribeToContractDisabledUpdates();
             await this.refreshContractDisabledState();
             this.subscribeToFeeConfigUpdates();
             
@@ -354,6 +356,26 @@ export class CreateOrder extends BaseComponent {
         };
 
         ws.subscribe('FeeConfigUpdated', this.feeConfigUpdatedHandler);
+    }
+
+    subscribeToContractDisabledUpdates() {
+        const ws = this.ctx.getWebSocket();
+        if (!ws?.subscribe) {
+            return;
+        }
+
+        if (this.contractDisabledHandler && ws.unsubscribe) {
+            ws.unsubscribe('ContractDisabled', this.contractDisabledHandler);
+        }
+
+        this.contractDisabledHandler = () => {
+            this.debug('ContractDisabled event received, disabling new orders');
+            this.contractStateReadError = false;
+            this.isContractDisabled = true;
+            this.updateCreateButtonState();
+        };
+
+        ws.subscribe('ContractDisabled', this.contractDisabledHandler);
     }
 
     async loadOrderCreationFee() {
@@ -1791,7 +1813,11 @@ export class CreateOrder extends BaseComponent {
         if (ws?.unsubscribe && this.feeConfigUpdatedHandler) {
             ws.unsubscribe('FeeConfigUpdated', this.feeConfigUpdatedHandler);
         }
+        if (ws?.unsubscribe && this.contractDisabledHandler) {
+            ws.unsubscribe('ContractDisabled', this.contractDisabledHandler);
+        }
         this.feeConfigUpdatedHandler = null;
+        this.contractDisabledHandler = null;
         this.pendingFeeConfigRefresh = false;
     }
 


### PR DESCRIPTION
## Summary
- subscribe `CreateOrder` to `ContractDisabled` so the create button is disabled immediately when the event is emitted
- add matching unsubscribe cleanup for the new `CreateOrder` subscription
- subscribe `ContractParams` to `ContractDisabled` and immediately update cached/visible `isDisabled` state so the Parameters tab reflects the change without refresh
- add matching unsubscribe cleanup in `ContractParams`
