### PR TITLE
Extract shared View/Taker order row helper context

### DIFF
--- a/js/components/TakerOrders.js
+++ b/js/components/TakerOrders.js
@@ -1,11 +1,11 @@
 import { BaseComponent } from './BaseComponent.js';
 import { createLogger } from '../services/LogService.js';
-import { ethers } from 'ethers';
 import { processOrderAddress, generateStatusCellHTML, setupClickToCopy } from '../utils/ui.js';
-import { formatTimeDiff, calculateTotalValue, formatDealValue } from '../utils/orderUtils.js';
+import { calculateTotalValue, formatDealValue } from '../utils/orderUtils.js';
 import { OrdersComponentHelper } from '../services/OrdersComponentHelper.js';
 import { OrdersTableRenderer } from '../services/OrdersTableRenderer.js';
-import { buildTokenDisplaySymbolMap, getDisplaySymbol } from '../utils/tokenDisplay.js';
+import { buildTokenDisplaySymbolMap } from '../utils/tokenDisplay.js';
+import { buildOrderRowContext } from '../utils/ordersComponentHelpers.js';
 
 export class TakerOrders extends BaseComponent {
     constructor() {
@@ -296,55 +296,28 @@ export class TakerOrders extends BaseComponent {
             tr.dataset.orderId = order.id.toString();
             tr.dataset.timestamp = order.timings?.createdAt?.toString() || '0';
 
-            // Get token info from WebSocket cache
             const ws = this.ctx.getWebSocket();
-            const sellTokenInfo = await ws.getTokenInfo(order.sellToken);
-            const buyTokenInfo = await ws.getTokenInfo(order.buyToken);
-            const sellDisplaySymbol = getDisplaySymbol(sellTokenInfo, this.tokenDisplaySymbolMap);
-            const buyDisplaySymbol = getDisplaySymbol(buyTokenInfo, this.tokenDisplaySymbolMap);
-
-            // Use pre-formatted values from dealMetrics
-            const { 
+            const pricing = this.ctx.getPricing();
+            const {
+                sellTokenInfo,
+                buyTokenInfo,
+                sellDisplaySymbol,
+                buyDisplaySymbol,
                 formattedSellAmount,
                 formattedBuyAmount,
-                sellTokenUsdPrice,
-                buyTokenUsdPrice 
-            } = order.dealMetrics || {};
-            
-            const deal = order.dealMetrics?.deal > 0 ? 1 / order.dealMetrics?.deal : undefined; // view as buyer/taker
-
-            // Fallback amount formatting if dealMetrics not yet populated
-            const safeFormattedSellAmount = typeof formattedSellAmount !== 'undefined'
-                ? formattedSellAmount
-                : (order?.sellAmount && sellTokenInfo?.decimals != null
-                    ? ethers.utils.formatUnits(order.sellAmount, sellTokenInfo.decimals)
-                    : '0');
-            const safeFormattedBuyAmount = typeof formattedBuyAmount !== 'undefined'
-                ? formattedBuyAmount
-                : (order?.buyAmount && buyTokenInfo?.decimals != null
-                    ? ethers.utils.formatUnits(order.buyAmount, buyTokenInfo.decimals)
-                    : '0');
-
-            // Determine prices with fallback to current pricing service map
-            const pricing = this.ctx.getPricing();
-            const resolvedSellPrice = typeof sellTokenUsdPrice !== 'undefined' 
-                ? sellTokenUsdPrice 
-                : (pricing ? pricing.getPrice(order.sellToken) : undefined);
-            const resolvedBuyPrice = typeof buyTokenUsdPrice !== 'undefined' 
-                ? buyTokenUsdPrice 
-                : (pricing ? pricing.getPrice(order.buyToken) : undefined);
-
-            // Mark as estimate if not explicitly present in pricing map
-            const sellPriceClass = (pricing && pricing.isPriceEstimated(order.sellToken)) ? 'price-estimate' : '';
-            const buyPriceClass = (pricing && pricing.isPriceEstimated(order.buyToken)) ? 'price-estimate' : '';
-
-            const orderStatus = ws.getOrderStatus(order);
-            const expiryEpoch = order?.timings?.expiresAt;
-            const currentTime = ws.getCurrentTimestamp();
-            const expiryText = orderStatus === 'Active' && typeof expiryEpoch === 'number' 
-                && Number.isFinite(currentTime)
-                ? formatTimeDiff(expiryEpoch - currentTime) 
-                : '';
+                resolvedSellPrice,
+                resolvedBuyPrice,
+                sellPriceClass,
+                buyPriceClass,
+                orderStatus,
+                expiryText,
+                buyerDealRatio
+            } = await buildOrderRowContext({
+                order,
+                ws,
+                pricing,
+                tokenDisplaySymbolMap: this.tokenDisplaySymbolMap
+            });
 
             // Get counterparty address for display
             const wallet = this.ctx.getWallet();
@@ -361,9 +334,9 @@ export class TakerOrders extends BaseComponent {
                         <div class="token-details">
                             <div class="token-symbol-row">
                                 <span class="token-symbol">${sellDisplaySymbol}</span>
-                                <span class="token-price ${sellPriceClass}">${calculateTotalValue(resolvedSellPrice, safeFormattedSellAmount)}</span>
+                                <span class="token-price ${sellPriceClass}">${calculateTotalValue(resolvedSellPrice, formattedSellAmount)}</span>
                             </div>
-                            <span class="token-amount">${safeFormattedSellAmount}</span>
+                            <span class="token-amount">${formattedSellAmount}</span>
                         </div>
                     </div>
                 </td>
@@ -375,13 +348,13 @@ export class TakerOrders extends BaseComponent {
                         <div class="token-details">
                             <div class="token-symbol-row">
                                 <span class="token-symbol">${buyDisplaySymbol}</span>
-                                <span class="token-price ${buyPriceClass}">${calculateTotalValue(resolvedBuyPrice, safeFormattedBuyAmount)}</span>
+                                <span class="token-price ${buyPriceClass}">${calculateTotalValue(resolvedBuyPrice, formattedBuyAmount)}</span>
                             </div>
-                            <span class="token-amount">${safeFormattedBuyAmount}</span>
+                            <span class="token-amount">${formattedBuyAmount}</span>
                         </div>
                     </div>
                 </td>
-                <td>${formatDealValue(deal)}</td>
+                <td>${formatDealValue(buyerDealRatio)}</td>
                 <td>${expiryText}</td>
                 <td class="order-status">
                     ${generateStatusCellHTML(orderStatus, counterpartyAddress, isZeroAddr, formattedAddress)}

--- a/js/components/ViewOrders.js
+++ b/js/components/ViewOrders.js
@@ -1,11 +1,11 @@
 import { BaseComponent } from './BaseComponent.js';
-import { ethers } from 'ethers';
 import { createLogger } from '../services/LogService.js';
 import { createDealCellHTML } from '../utils/ui.js';
-import { formatTimeDiff, calculateTotalValue } from '../utils/orderUtils.js';
+import { calculateTotalValue } from '../utils/orderUtils.js';
 import { OrdersComponentHelper } from '../services/OrdersComponentHelper.js';
 import { OrdersTableRenderer } from '../services/OrdersTableRenderer.js';
-import { buildTokenDisplaySymbolMap, getDisplaySymbol } from '../utils/tokenDisplay.js';
+import { buildTokenDisplaySymbolMap } from '../utils/tokenDisplay.js';
+import { buildOrderRowContext } from '../utils/ordersComponentHelpers.js';
 
 export class ViewOrders extends BaseComponent {
     constructor(containerId = 'view-orders') {
@@ -297,54 +297,29 @@ export class ViewOrders extends BaseComponent {
             tr.dataset.orderId = order.id.toString();
             tr.dataset.timestamp = order.timings?.createdAt?.toString() || '0';
 
-            // Get token info from WebSocket cache
             const ws = this.ctx.getWebSocket();
-            const sellTokenInfo = await ws.getTokenInfo(order.sellToken);
-            const buyTokenInfo = await ws.getTokenInfo(order.buyToken);
-            const sellDisplaySymbol = getDisplaySymbol(sellTokenInfo, this.tokenDisplaySymbolMap);
-            const buyDisplaySymbol = getDisplaySymbol(buyTokenInfo, this.tokenDisplaySymbolMap);
-            const deal = order.dealMetrics?.deal > 0 ? 1 / order.dealMetrics?.deal : undefined; // view as buyer/taker
-            // Use pre-formatted values from dealMetrics
-            const { 
+            const pricing = this.ctx.getPricing();
+            const {
+                sellTokenInfo,
+                buyTokenInfo,
+                sellDisplaySymbol,
+                buyDisplaySymbol,
                 formattedSellAmount,
                 formattedBuyAmount,
-                sellTokenUsdPrice,
-                buyTokenUsdPrice 
-            } = order.dealMetrics || {};
-
-            // Fallback amount formatting if dealMetrics not yet populated
-            const safeFormattedSellAmount = typeof formattedSellAmount !== 'undefined'
-                ? formattedSellAmount
-                : (order?.sellAmount && sellTokenInfo?.decimals != null
-                    ? ethers.utils.formatUnits(order.sellAmount, sellTokenInfo.decimals)
-                    : '0');
-            const safeFormattedBuyAmount = typeof formattedBuyAmount !== 'undefined'
-                ? formattedBuyAmount
-                : (order?.buyAmount && buyTokenInfo?.decimals != null
-                    ? ethers.utils.formatUnits(order.buyAmount, buyTokenInfo.decimals)
-                    : '0');
-
-            // Determine prices with fallback to current pricing service map
-            const pricing = this.ctx.getPricing();
-            const resolvedSellPrice = typeof sellTokenUsdPrice !== 'undefined' 
-                ? sellTokenUsdPrice 
-                : (pricing ? pricing.getPrice(order.sellToken) : undefined);
-            const resolvedBuyPrice = typeof buyTokenUsdPrice !== 'undefined' 
-                ? buyTokenUsdPrice 
-                : (pricing ? pricing.getPrice(order.buyToken) : undefined);
-
-            // Mark as estimate if not explicitly present in pricing map
-            const sellPriceClass = (pricing && pricing.isPriceEstimated(order.sellToken)) ? 'price-estimate' : '';
-            const buyPriceClass = (pricing && pricing.isPriceEstimated(order.buyToken)) ? 'price-estimate' : '';
-
-            const orderStatus = ws.getOrderStatus(order);
-            const expiryEpoch = order?.timings?.expiresAt;
-            const currentTime = ws.getCurrentTimestamp();
-            const expiryText = orderStatus === 'Active' && typeof expiryEpoch === 'number' 
-                && Number.isFinite(currentTime)
-                ? formatTimeDiff(expiryEpoch - currentTime) 
-                : '';
-            const dealText = deal !== undefined ? (deal || 0).toFixed(6) : 'N/A';
+                resolvedSellPrice,
+                resolvedBuyPrice,
+                sellPriceClass,
+                buyPriceClass,
+                orderStatus,
+                expiryText,
+                buyerDealRatio
+            } = await buildOrderRowContext({
+                order,
+                ws,
+                pricing,
+                tokenDisplaySymbolMap: this.tokenDisplaySymbolMap
+            });
+            const dealText = buyerDealRatio !== undefined ? (buyerDealRatio || 0).toFixed(6) : 'N/A';
 
             tr.innerHTML = `
                 <td>${order.id}</td>
@@ -356,9 +331,9 @@ export class ViewOrders extends BaseComponent {
                         <div class="token-details">
                             <div class="token-symbol-row">
                                 <span class="token-symbol">${sellDisplaySymbol}</span>
-                                <span class="token-price ${sellPriceClass}">${calculateTotalValue(resolvedSellPrice, safeFormattedSellAmount)}</span>
+                                <span class="token-price ${sellPriceClass}">${calculateTotalValue(resolvedSellPrice, formattedSellAmount)}</span>
                             </div>
-                            <span class="token-amount">${safeFormattedSellAmount}</span>
+                            <span class="token-amount">${formattedSellAmount}</span>
                         </div>
                     </div>
                 </td>
@@ -370,9 +345,9 @@ export class ViewOrders extends BaseComponent {
                         <div class="token-details">
                             <div class="token-symbol-row">
                                 <span class="token-symbol">${buyDisplaySymbol}</span>
-                                <span class="token-price ${buyPriceClass}">${calculateTotalValue(resolvedBuyPrice, safeFormattedBuyAmount)}</span>
+                                <span class="token-price ${buyPriceClass}">${calculateTotalValue(resolvedBuyPrice, formattedBuyAmount)}</span>
                             </div>
-                            <span class="token-amount">${safeFormattedBuyAmount}</span>
+                            <span class="token-amount">${formattedBuyAmount}</span>
                         </div>
                     </div>
                 </td>

--- a/js/utils/ordersComponentHelpers.js
+++ b/js/utils/ordersComponentHelpers.js
@@ -1,0 +1,67 @@
+import { ethers } from 'ethers';
+import { formatTimeDiff } from './orderUtils.js';
+import { getDisplaySymbol } from './tokenDisplay.js';
+
+export async function buildOrderRowContext({
+    order,
+    ws,
+    pricing,
+    tokenDisplaySymbolMap
+}) {
+    const sellTokenInfo = await ws.getTokenInfo(order.sellToken);
+    const buyTokenInfo = await ws.getTokenInfo(order.buyToken);
+    const sellDisplaySymbol = getDisplaySymbol(sellTokenInfo, tokenDisplaySymbolMap);
+    const buyDisplaySymbol = getDisplaySymbol(buyTokenInfo, tokenDisplaySymbolMap);
+
+    const {
+        formattedSellAmount,
+        formattedBuyAmount,
+        sellTokenUsdPrice,
+        buyTokenUsdPrice
+    } = order.dealMetrics || {};
+
+    const safeFormattedSellAmount = typeof formattedSellAmount !== 'undefined'
+        ? formattedSellAmount
+        : (order?.sellAmount && sellTokenInfo?.decimals != null
+            ? ethers.utils.formatUnits(order.sellAmount, sellTokenInfo.decimals)
+            : '0');
+    const safeFormattedBuyAmount = typeof formattedBuyAmount !== 'undefined'
+        ? formattedBuyAmount
+        : (order?.buyAmount && buyTokenInfo?.decimals != null
+            ? ethers.utils.formatUnits(order.buyAmount, buyTokenInfo.decimals)
+            : '0');
+
+    const resolvedSellPrice = typeof sellTokenUsdPrice !== 'undefined'
+        ? sellTokenUsdPrice
+        : (pricing ? pricing.getPrice(order.sellToken) : undefined);
+    const resolvedBuyPrice = typeof buyTokenUsdPrice !== 'undefined'
+        ? buyTokenUsdPrice
+        : (pricing ? pricing.getPrice(order.buyToken) : undefined);
+
+    const sellPriceClass = (pricing && pricing.isPriceEstimated(order.sellToken)) ? 'price-estimate' : '';
+    const buyPriceClass = (pricing && pricing.isPriceEstimated(order.buyToken)) ? 'price-estimate' : '';
+
+    const orderStatus = ws.getOrderStatus(order);
+    const expiryEpoch = order?.timings?.expiresAt;
+    const currentTime = ws.getCurrentTimestamp();
+    const expiryText = orderStatus === 'Active' && typeof expiryEpoch === 'number'
+        && Number.isFinite(currentTime)
+        ? formatTimeDiff(expiryEpoch - currentTime)
+        : '';
+
+    return {
+        sellTokenInfo,
+        buyTokenInfo,
+        sellDisplaySymbol,
+        buyDisplaySymbol,
+        formattedSellAmount: safeFormattedSellAmount,
+        formattedBuyAmount: safeFormattedBuyAmount,
+        resolvedSellPrice,
+        resolvedBuyPrice,
+        sellPriceClass,
+        buyPriceClass,
+        orderStatus,
+        expiryText,
+        buyerDealRatio: order.dealMetrics?.deal > 0 ? 1 / order.dealMetrics?.deal : undefined
+    };
+}

--- a/tests/ordersComponentHelpers.test.js
+++ b/tests/ordersComponentHelpers.test.js
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from 'vitest';
+import { buildOrderRowContext } from '../js/utils/ordersComponentHelpers.js';
+
+const TOKEN_A = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const TOKEN_B = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+function createWsStub({ status = 'Active', currentTimestamp = 1_700_000_000 } = {}) {
+    return {
+        getTokenInfo: vi.fn(async (address) => {
+            if (address.toLowerCase() === TOKEN_A) {
+                return { address: TOKEN_A, symbol: 'AAA', decimals: 18 };
+            }
+            return { address: TOKEN_B, symbol: 'BBB', decimals: 6 };
+        }),
+        getOrderStatus: vi.fn(() => status),
+        getCurrentTimestamp: vi.fn(() => currentTimestamp)
+    };
+}
+
+describe('ordersComponentHelpers', () => {
+    it('builds row context from dealMetrics values when present', async () => {
+        const ws = createWsStub();
+        const pricing = {
+            getPrice: vi.fn(() => 999),
+            isPriceEstimated: vi.fn((address) => address.toLowerCase() === TOKEN_A)
+        };
+        const tokenDisplaySymbolMap = new Map([
+            [TOKEN_A, 'AAA.issuer'],
+            [TOKEN_B, 'BBB']
+        ]);
+        const order = {
+            sellToken: TOKEN_A,
+            buyToken: TOKEN_B,
+            sellAmount: '1000000000000000000',
+            buyAmount: '1230000',
+            timings: {
+                expiresAt: 1_700_003_600
+            },
+            dealMetrics: {
+                formattedSellAmount: '1.00',
+                formattedBuyAmount: '1.23',
+                sellTokenUsdPrice: 10,
+                buyTokenUsdPrice: 20,
+                deal: 2
+            }
+        };
+
+        const result = await buildOrderRowContext({ order, ws, pricing, tokenDisplaySymbolMap });
+
+        expect(result.sellDisplaySymbol).toBe('AAA.issuer');
+        expect(result.buyDisplaySymbol).toBe('BBB');
+        expect(result.formattedSellAmount).toBe('1.00');
+        expect(result.formattedBuyAmount).toBe('1.23');
+        expect(result.resolvedSellPrice).toBe(10);
+        expect(result.resolvedBuyPrice).toBe(20);
+        expect(result.sellPriceClass).toBe('price-estimate');
+        expect(result.buyPriceClass).toBe('');
+        expect(result.orderStatus).toBe('Active');
+        expect(result.expiryText).toBe('1H 0M');
+        expect(result.buyerDealRatio).toBe(0.5);
+    });
+
+    it('builds row context from fallback amount and pricing when metrics are absent', async () => {
+        const ws = createWsStub({ status: 'Filled' });
+        const pricing = {
+            getPrice: vi.fn((address) => (address.toLowerCase() === TOKEN_A ? 3 : 7)),
+            isPriceEstimated: vi.fn(() => false)
+        };
+        const order = {
+            sellToken: TOKEN_A,
+            buyToken: TOKEN_B,
+            sellAmount: '2000000',
+            buyAmount: '900000',
+            timings: {
+                expiresAt: 1_700_003_600
+            }
+        };
+
+        const result = await buildOrderRowContext({
+            order,
+            ws,
+            pricing,
+            tokenDisplaySymbolMap: new Map()
+        });
+
+        expect(result.formattedSellAmount).toBe('2000000');
+        expect(result.formattedBuyAmount).toBe('900000');
+        expect(result.resolvedSellPrice).toBe(3);
+        expect(result.resolvedBuyPrice).toBe(7);
+        expect(result.expiryText).toBe('');
+        expect(result.buyerDealRatio).toBeUndefined();
+    });
+});

--- a/tests/ordersTabs.displaySymbol.test.js
+++ b/tests/ordersTabs.displaySymbol.test.js
@@ -17,31 +17,44 @@ const TOKEN_INFO = {
     [TOKEN_C]: { address: TOKEN_C, symbol: 'USDC', name: 'USD Coin', decimals: 6 }
 };
 
-function createWsStub({ includeCache = false } = {}) {
+function createWsStub({
+    includeCache = false,
+    tokenInfoMap = TOKEN_INFO,
+    orderStatus = 'Active',
+    currentTimestamp = 1_700_000_000,
+    canFillOrder = false
+} = {}) {
     const ws = {
-        getTokenInfo: vi.fn(async (address) => TOKEN_INFO[address.toLowerCase()] || null),
-        getOrderStatus: vi.fn(() => 'Active'),
-        getCurrentTimestamp: vi.fn(() => 1_700_000_000),
+        getTokenInfo: vi.fn(async (address) => tokenInfoMap[address.toLowerCase()] || null),
+        getOrderStatus: vi.fn(() => orderStatus),
+        getCurrentTimestamp: vi.fn(() => currentTimestamp),
         canCancelOrder: vi.fn(() => false),
-        canFillOrder: vi.fn(() => false)
+        canFillOrder: vi.fn(() => canFillOrder)
     };
 
     if (includeCache) {
         ws.tokenCache = new Map(
-            Object.values(TOKEN_INFO).map((token) => [token.address.toLowerCase(), token])
+            Object.values(tokenInfoMap).map((token) => [token.address.toLowerCase(), token])
         );
     }
 
     return ws;
 }
 
-function createContext(ws, walletAddress = MAKER) {
+function createContext(
+    ws,
+    walletAddress = MAKER,
+    {
+        pricingByToken = {},
+        estimatedTokens = []
+    } = {}
+) {
     return {
         getWebSocket: () => ws,
         getWalletChainId: () => '0x89',
         getPricing: () => ({
-            getPrice: () => undefined,
-            isPriceEstimated: () => false
+            getPrice: (token) => pricingByToken[token?.toLowerCase?.()] ?? undefined,
+            isPriceEstimated: (token) => estimatedTokens.includes(token?.toLowerCase?.())
         }),
         getWallet: () => ({
             getAccount: () => walletAddress,
@@ -71,6 +84,22 @@ function createOrder() {
             formattedSellAmount: '1.00',
             formattedBuyAmount: '1.00',
             deal: 1
+        }
+    };
+}
+
+function createFallbackOrder() {
+    return {
+        id: 2,
+        maker: MAKER,
+        taker: TAKER,
+        sellToken: TOKEN_A,
+        buyToken: TOKEN_B,
+        sellAmount: '2000000',
+        buyAmount: '500000',
+        timings: {
+            createdAt: 1_700_000_000,
+            expiresAt: 1_700_003_600
         }
     };
 }
@@ -163,5 +192,90 @@ describe('orders tabs display symbol rendering', () => {
             .map((element) => element.textContent.trim());
 
         expect(symbols).toEqual(['AAA.issuer', 'AAA']);
+    });
+
+    it('uses fallback formatting, price classes, and expiry text in ViewOrders rows', async () => {
+        document.body.innerHTML = '<div id="view-orders"></div>';
+
+        const tokenInfoMap = {
+            [TOKEN_A]: { address: TOKEN_A, symbol: 'AAA', name: 'Token A', decimals: 6 },
+            [TOKEN_B]: { address: TOKEN_B, symbol: 'BBB', name: 'Token B', decimals: 6 }
+        };
+        const ws = createWsStub({ tokenInfoMap, orderStatus: 'Active', currentTimestamp: 1_700_000_000 });
+        const component = new ViewOrders();
+        component.setContext(createContext(ws, MAKER, {
+            pricingByToken: {
+                [TOKEN_A]: 2,
+                [TOKEN_B]: 3
+            },
+            estimatedTokens: [TOKEN_A]
+        }));
+        component.tokenDisplaySymbolMap = new Map([
+            [TOKEN_A, 'AAA.issuer'],
+            [TOKEN_B, 'BBB']
+        ]);
+        component.helper.renderTokenIcon = vi.fn();
+        component.renderer.startExpiryTimer = vi.fn();
+
+        const row = await component.createOrderRow(createFallbackOrder());
+        const tokenAmounts = Array.from(row.querySelectorAll('.token-amount'))
+            .map((element) => element.textContent.trim());
+        const tokenPrices = Array.from(row.querySelectorAll('.token-price'))
+            .map((element) => element.textContent.trim());
+        const tokenPriceClasses = Array.from(row.querySelectorAll('.token-price'))
+            .map((element) => element.classList.contains('price-estimate'));
+        const expiryText = row.querySelector('td:nth-child(5)')?.textContent?.trim();
+        const dealText = row.querySelector('.deal-value')?.textContent?.trim();
+
+        expect(tokenAmounts).toEqual(['2000000', '500000']);
+        expect(tokenPrices).toEqual(['$4000000', '$1500000']);
+        expect(tokenPriceClasses).toEqual([true, false]);
+        expect(expiryText).toBe('1H 0M');
+        expect(dealText).toBe('N/A');
+    });
+
+    it('uses fallback formatting, price classes, and expiry text in TakerOrders rows', async () => {
+        document.body.innerHTML = '<div id="taker-orders"></div>';
+
+        const tokenInfoMap = {
+            [TOKEN_A]: { address: TOKEN_A, symbol: 'AAA', name: 'Token A', decimals: 6 },
+            [TOKEN_B]: { address: TOKEN_B, symbol: 'BBB', name: 'Token B', decimals: 6 }
+        };
+        const ws = createWsStub({
+            tokenInfoMap,
+            orderStatus: 'Active',
+            currentTimestamp: 1_700_000_000,
+            canFillOrder: true
+        });
+        const component = new TakerOrders();
+        component.setContext(createContext(ws, TAKER, {
+            pricingByToken: {
+                [TOKEN_A]: 2,
+                [TOKEN_B]: 3
+            },
+            estimatedTokens: [TOKEN_A]
+        }));
+        component.tokenDisplaySymbolMap = new Map([
+            [TOKEN_A, 'AAA.issuer'],
+            [TOKEN_B, 'BBB']
+        ]);
+        component.helper.renderTokenIcon = vi.fn();
+        component.renderer.startExpiryTimer = vi.fn();
+
+        const row = await component.createOrderRow(createFallbackOrder());
+        const tokenAmounts = Array.from(row.querySelectorAll('.token-amount'))
+            .map((element) => element.textContent.trim());
+        const tokenPrices = Array.from(row.querySelectorAll('.token-price'))
+            .map((element) => element.textContent.trim());
+        const tokenPriceClasses = Array.from(row.querySelectorAll('.token-price'))
+            .map((element) => element.classList.contains('price-estimate'));
+        const expiryText = row.querySelector('td:nth-child(5)')?.textContent?.trim();
+        const dealText = row.querySelector('td:nth-child(4)')?.textContent?.trim();
+
+        expect(tokenAmounts).toEqual(['2000000', '500000']);
+        expect(tokenPrices).toEqual(['$4000000', '$1500000']);
+        expect(tokenPriceClasses).toEqual([true, false]);
+        expect(expiryText).toBe('1H 0M');
+        expect(dealText).toBe('N/A');
     });
 });


### PR DESCRIPTION
## Summary
- extract shared ViewOrders/TakerOrders row-prep logic into `js/utils/ordersComponentHelpers.js`
- refactor `ViewOrders` and `TakerOrders` to use `buildOrderRowContext(...)`
- preserve each tab's unique rendering and action/status behavior while removing duplicated prep logic

## Tests
- add `tests/ordersComponentHelpers.test.js`
- expand `tests/ordersTabs.displaySymbol.test.js` coverage for fallback formatting, price class, expiry text, and display symbol behavior

### Verification
- `npm test`
- result: 6 files, 20 tests passing
