### PR TITLE
Use HTTP RPC for getAllowedTokens() to avoid WS timeout on startup

### DIFF
--- a/js/services/ContractService.js
+++ b/js/services/ContractService.js
@@ -79,7 +79,9 @@ class ContractService {
                 this.debug(`Trying HTTP RPC: ${url}`);
                 const httpProvider = new ethers.providers.JsonRpcProvider(url);
                 const httpContract = new ethers.Contract(net.contractAddress, net.contractABI, httpProvider);
-                return await readFn(httpContract);
+                const result = await readFn(httpContract);
+                this.debug(`HTTP RPC succeeded: ${url}`);
+                return result;
             } catch (e) {
                 lastErr = e;
                 this.warn(`HTTP RPC failed (${url}):`, e?.message || e);


### PR DESCRIPTION
- **Goal:** Use HTTP RPC for allowed-token reads so startup no longer hits WebSocket timeouts.
- **ContractService:** Added `_readViaHttpRpc(readFn)` that tries `rpcUrl` then `fallbackRpcUrls`, builds a one-off HTTP contract, and runs the read; logs which URL is tried and which one succeeds.
- **getAllowedTokens() / getAllowedTokensCount():** Both now call only `_readViaHttpRpc`; no WebSocket or rate-limit fallback logic.
- **Call sites:** Unchanged (PricingService, contractTokens, Admin, getContractInfo); they automatically use HTTP for these reads.
- **Trade-off:** Better startup reliability and no WS dependency for these reads; slight extra cost from creating HTTP providers per call, no connection reuse.