### PR TITLE
Fix: Multicall order decode mismatch & OrderCreated event parsing

### DIFF
--- a/js/services/WebSocket.js
+++ b/js/services/WebSocket.js
@@ -659,11 +659,12 @@ export class WebSocketService {
 
             contract.on("OrderCreated", async (...args) => {
                 try {
-                    if (!args || args.length < 9) {
-                        this.debug('Invalid OrderCreated event args:', args);
+                    const event = args[args.length - 1];
+                    if (!event || !event.args) {
+                        this.debug('Invalid OrderCreated event, missing event.args:', event);
                         return;
                     }
-                    const [orderId, maker, taker, sellToken, sellAmount, buyToken, buyAmount, timestamp, fee, event] = args;
+                    const { orderId, maker, taker, sellToken, sellAmount, buyToken, buyAmount, timestamp, feeToken, orderCreationFee } = event.args;
                     const createdAt = timestamp.toNumber();
                     
                     let orderData = {
@@ -677,8 +678,8 @@ export class WebSocketService {
                         timestamp: createdAt,
                         timings: this.buildOrderTimings(createdAt),
                         status: 'Active',
-                        orderCreationFee: fee,
-                        tries: 0
+                        feeToken,
+                        orderCreationFee
                     };
 
                     // Calculate and add deal metrics


### PR DESCRIPTION
### Problem
- **Multicall decode failure:** `[WEBSOCKET] Failed to decode order N from multicall Error: call revert exception` when fetching orders via Multicall2. The code used a **hardcoded** `orders(uint256)` ABI that included an 11th return value `tries`, while the deployed contract (and `OTCSwap.js` ABI) returns **10** values. That mismatch caused `decodeFunctionResult` to fail.
- **OrderCreated handler:** The handler used positional destructuring `(..., timestamp, fee, event)` and mapped the 9th argument (`feeToken`) into `orderCreationFee`, dropped the real `orderCreationFee`, and used a stale `args.length < 9` guard and `tries: 0` on the built order object.

### Changes

**Read/decode paths**
- Removed the static `getOrdersInterface()` helper and its hardcoded 11-field ABI.
- `fetchOrdersViaMulticall()` now uses `this.contract.interface` (from the deployment ABI) so the decode shape always matches the contract.
- Decode destructuring expects 10 fields; removed `tries` from decoded order objects in both multicall and individual-fallback paths.
- Simplified timestamp handling (rely on `timestamp.toNumber()` from contract return values).

**OrderCreated event**
- Switched to **named** `event.args` instead of positional args so `feeToken` and `orderCreationFee` are correct.
- Replaced the `args.length < 9` guard with validation that `event.args` exists.
- Removed `tries: 0` from the built order object; added `feeToken` and `orderCreationFee` explicitly.

### Why this helps
- **Single source of truth:** Order decoding and event parsing both align with the contract ABI in `OTCSwap.js`; no duplicate or outdated signatures.
- **Robust to ABI changes:** Using `contract.interface` and `event.args` keeps the UI in sync when the contract’s `orders()` or `OrderCreated` definition changes.
- **Correct data:** New orders from the event now get the right `feeToken` and `orderCreationFee` instead of misassigned values, and all order records no longer reference the removed `tries` field.
