### PR TITLE
Left align deal column in order tabs

### DIFF
--- a/css/components/orders.css
+++ b/css/components/orders.css
@@ -201,7 +201,7 @@ button.info-icon.order-tooltip-icon {
 .deal-cell-content {
   display: flex;
   align-items: center;
-  justify-content: flex-end;
+  justify-content: flex-start;
   gap: 0.35rem;
 }
 
@@ -647,7 +647,8 @@ button.info-icon.order-tooltip-icon {
   }
 
   .deal-cell-content {
-    justify-content: space-between;
+    justify-content: flex-start;
+    flex-wrap: wrap;
     width: 100%;
   }
 

--- a/js/components/MyOrders.js
+++ b/js/components/MyOrders.js
@@ -11,7 +11,7 @@ import {
     setupClickToCopy,
     setupOrderTooltips
 } from '../utils/ui.js';
-import { formatTimeDiff, calculateTotalValue } from '../utils/orderUtils.js';
+import { formatTimeDiff, calculateTotalValue, formatDealValue } from '../utils/orderUtils.js';
 import { OrdersComponentHelper } from '../services/OrdersComponentHelper.js';
 import { OrdersTableRenderer } from '../services/OrdersTableRenderer.js';
 import { buildTokenDisplaySymbolMap, getDisplaySymbol } from '../utils/tokenDisplay.js';
@@ -682,7 +682,7 @@ export class MyOrders extends BaseComponent {
             const wallet = this.ctx.getWallet();
             const userAddress = wallet?.getAccount()?.toLowerCase();
             const { counterpartyAddress, isZeroAddr, formattedAddress } = processOrderAddress(order, userAddress);
-            const dealText = deal !== undefined ? (deal || 0).toFixed(6) : 'N/A';
+            const dealText = formatDealValue(deal);
             tr.innerHTML = `
                 <td>${order.id}</td>
                 <td>

--- a/js/components/ViewOrders.js
+++ b/js/components/ViewOrders.js
@@ -1,7 +1,7 @@
 import { BaseComponent } from './BaseComponent.js';
 import { createLogger } from '../services/LogService.js';
 import { createDealCellHTML } from '../utils/ui.js';
-import { calculateTotalValue } from '../utils/orderUtils.js';
+import { calculateTotalValue, formatDealValue } from '../utils/orderUtils.js';
 import { OrdersComponentHelper } from '../services/OrdersComponentHelper.js';
 import { OrdersTableRenderer } from '../services/OrdersTableRenderer.js';
 import { buildTokenDisplaySymbolMap } from '../utils/tokenDisplay.js';
@@ -319,7 +319,7 @@ export class ViewOrders extends BaseComponent {
                 pricing,
                 tokenDisplaySymbolMap: this.tokenDisplaySymbolMap
             });
-            const dealText = buyerDealRatio !== undefined ? (buyerDealRatio || 0).toFixed(6) : 'N/A';
+            const dealText = formatDealValue(buyerDealRatio);
 
             tr.innerHTML = `
                 <td>${order.id}</td>


### PR DESCRIPTION
## Summary
- left align the Deal column content across View Orders, My Orders, and Taker Orders
- keep the mobile deal card layout left aligned as well
- use the shared deal formatter so displayed ratios no longer show unnecessary trailing zeroes

## Testing
- npm test

<img width="1200" height="655" alt="image" src="https://github.com/user-attachments/assets/3205a689-7291-4822-b61e-36d9c3fefbe0" />

Closes #71