### PR TITLE
Deal cell consistency 

### DIFF
--- a/css/components/orders.css
+++ b/css/components/orders.css
@@ -647,8 +647,10 @@ button.info-icon.order-tooltip-icon {
   }
 
   .deal-cell-content {
+    flex-direction: column;
+    align-items: flex-start;
     justify-content: flex-start;
-    flex-wrap: wrap;
+    gap: inherit;
     width: 100%;
   }
 

--- a/js/components/TakerOrders.js
+++ b/js/components/TakerOrders.js
@@ -1,6 +1,6 @@
 import { BaseComponent } from './BaseComponent.js';
 import { createLogger } from '../services/LogService.js';
-import { processOrderAddress, generateStatusCellHTML, setupClickToCopy } from '../utils/ui.js';
+import { createDealCellHTML, processOrderAddress, generateStatusCellHTML, setupClickToCopy } from '../utils/ui.js';
 import { calculateTotalValue, formatDealValue } from '../utils/orderUtils.js';
 import { OrdersComponentHelper } from '../services/OrdersComponentHelper.js';
 import { OrdersTableRenderer } from '../services/OrdersTableRenderer.js';
@@ -256,30 +256,6 @@ export class TakerOrders extends BaseComponent {
             } else {
                 this.warn('Advanced filters element not found');
             }
-            
-            // Customize table header
-            const thead = this.container.querySelector('thead tr');
-            if (!thead) {
-                this.error('Table header element not found');
-                return;
-            }
-
-            thead.innerHTML = `
-                <th>ID</th>
-                <th>Buy</th>
-                <th>Sell</th>
-                <th>
-                    Deal
-                    <span class="info-icon" title="Deal = Buy Value / Sell Value
-
-• Higher deal number is better
-• Deal > 1: better deal based on market prices
-• Deal < 1: worse deal based on market prices">ⓘ</span>
-                </th>
-                <th>Expires</th>
-                <th>Status</th>
-                <th>Action</th>
-            `;
         } catch (error) {
             this.error('Error setting up table:', error);
         }
@@ -354,7 +330,7 @@ export class TakerOrders extends BaseComponent {
                         </div>
                     </div>
                 </td>
-                <td>${formatDealValue(buyerDealRatio)}</td>
+                <td class="deal-cell">${createDealCellHTML(formatDealValue(buyerDealRatio))}</td>
                 <td>${expiryText}</td>
                 <td class="order-status">
                     ${generateStatusCellHTML(orderStatus, counterpartyAddress, isZeroAddr, formattedAddress)}

--- a/tests/ordersTabs.displaySymbol.test.js
+++ b/tests/ordersTabs.displaySymbol.test.js
@@ -270,12 +270,14 @@ describe('orders tabs display symbol rendering', () => {
         const tokenPriceClasses = Array.from(row.querySelectorAll('.token-price'))
             .map((element) => element.classList.contains('price-estimate'));
         const expiryText = row.querySelector('td:nth-child(5)')?.textContent?.trim();
-        const dealText = row.querySelector('td:nth-child(4)')?.textContent?.trim();
+        const dealText = row.querySelector('.deal-value')?.textContent?.trim();
+        const dealLabel = row.querySelector('.deal-card-label')?.textContent?.trim();
 
         expect(tokenAmounts).toEqual(['2.0', '0.5']);
         expect(tokenPrices).toEqual(['$4.00', '$1.50']);
         expect(tokenPriceClasses).toEqual([true, false]);
         expect(expiryText).toBe('1H 0M');
+        expect(dealLabel).toContain('Deal');
         expect(dealText).toBe('N/A');
     });
 });


### PR DESCRIPTION
## Summary
- apply the shared deal cell helper to TakerOrders so all three order tabs render deal values with the same row markup
- keep TakerOrders on the shared renderer header instead of overriding the deal header locally
- stack the mobile deal card label/value like the ID card, while keeping the tooltip inline with the label
- match the mobile deal card spacing to the other order cards

## Context
PR #75 merged before these follow-up commits were added to its branch. This PR contains only the changes that were still missing from main.

## Testing
- npm test

<img width="421" height="661" alt="image" src="https://github.com/user-attachments/assets/bbf5e4ce-3dfb-4eca-8156-f2d9cfc25247" />
<img width="1194" height="426" alt="image" src="https://github.com/user-attachments/assets/9badf484-7fa2-4c5e-b335-c842b03312be" />
