### PR TITLE
Fix missing bottom page-size selectors on shared order tabs

### DIFF
--- a/js/services/OrdersTableRenderer.js
+++ b/js/services/OrdersTableRenderer.js
@@ -254,6 +254,13 @@ export class OrdersTableRenderer {
             <div class="filter-row">
                 ${refreshSection}
                 <div class="pagination-controls">
+                    <select class="page-size-select">
+                        <option value="10">10 per page</option>
+                        <option value="25" selected>25 per page</option>
+                        <option value="50">50 per page</option>
+                        <option value="100">100 per page</option>
+                        <option value="-1">View all</option>
+                    </select>
                     <div class="pagination-buttons">
                         <button class="pagination-button prev-page" title="Previous page">←</button>
                         <span class="page-info">Page 1 of 1</span>
@@ -286,7 +293,7 @@ export class OrdersTableRenderer {
         const buyTokenFilter = filterControls.querySelector('#buy-token-filter');
         const orderSort = filterControls.querySelector('#order-sort');
         const toggle = filterControls.querySelector('#fillable-orders-toggle');
-        const pageSizeSelect = filterControls.querySelector('#page-size-select');
+        const pageSizeSelects = Array.from(this.component.container.querySelectorAll('.page-size-select'));
         
         if (sellTokenFilter) {
             sellTokenFilter.addEventListener('change', () => {
@@ -311,12 +318,17 @@ export class OrdersTableRenderer {
                 if (onRefresh) onRefresh();
             });
         }
-        if (pageSizeSelect) {
-            pageSizeSelect.addEventListener('change', () => {
+        pageSizeSelects.forEach((pageSizeSelect) => {
+            pageSizeSelect.addEventListener('change', (event) => {
+                pageSizeSelects.forEach((otherSelect) => {
+                    if (otherSelect !== event.target) {
+                        otherSelect.value = event.target.value;
+                    }
+                });
                 this.component.currentPage = 1;
                 if (onRefresh) onRefresh();
             });
-        }
+        });
         
         // Pagination listeners
         this._setupPaginationListeners(onRefresh);

--- a/tests/ordersTableRenderer.pagination.test.js
+++ b/tests/ordersTableRenderer.pagination.test.js
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { OrdersTableRenderer } from '../js/services/OrdersTableRenderer.js';
+
+function createRenderer() {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
+    const component = {
+        container,
+        currentPage: 1,
+        totalOrders: 120,
+        createElement(tag, className = '') {
+            const element = document.createElement(tag);
+            if (className) {
+                element.className = className;
+            }
+            return element;
+        },
+        ctx: {
+            getWebSocket: () => ({
+                tokenCache: new Map()
+            }),
+            getWalletChainId: () => '0x89'
+        }
+    };
+
+    return {
+        component,
+        renderer: new OrdersTableRenderer(component, { showRefreshButton: false })
+    };
+}
+
+afterEach(() => {
+    document.body.innerHTML = '';
+});
+
+describe('OrdersTableRenderer pagination controls', () => {
+    it('renders page size selectors in both top and bottom filter controls', async () => {
+        const { component, renderer } = createRenderer();
+
+        await renderer.setupTable(() => {});
+
+        expect(component.container.querySelectorAll('.page-size-select')).toHaveLength(2);
+        expect(component.container.querySelector('.bottom-controls .page-size-select')).not.toBeNull();
+    });
+
+    it('syncs page size changes between both controls before refreshing', async () => {
+        const { component, renderer } = createRenderer();
+        const onRefresh = vi.fn();
+
+        await renderer.setupTable(onRefresh);
+
+        const [topSelect, bottomSelect] = component.container.querySelectorAll('.page-size-select');
+        component.currentPage = 4;
+
+        bottomSelect.value = '50';
+        bottomSelect.dispatchEvent(new Event('change', { bubbles: true }));
+
+        expect(topSelect.value).toBe('50');
+        expect(bottomSelect.value).toBe('50');
+        expect(component.currentPage).toBe(1);
+        expect(onRefresh).toHaveBeenCalledOnce();
+
+        renderer.updatePaginationControls(component.totalOrders);
+        expect(
+            Array.from(component.container.querySelectorAll('.page-info')).map((element) => element.textContent)
+        ).toEqual([
+            '1-50 of 120 orders (Page 1 of 3)',
+            '1-50 of 120 orders (Page 1 of 3)'
+        ]);
+    });
+});


### PR DESCRIPTION
## Summary
- add the page-size selector to the shared bottom pagination controls used by View Orders and Invited Orders
- keep the top and bottom page-size selectors synchronized and reset pagination on change
- add a renderer regression test covering dual page-size controls

## Testing
- npm test

Fixes #81