### PR TITLE
[Stack 3/5] Add CreateOrder cache restore and balance hydration

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -56,6 +56,8 @@ class App {
 		this.pricingOrderStateHandler = null;
 		this.pricingOrderStateSource = null;
 		this.webSocketBootstrapPromise = null;
+		this.pricingBootstrapScheduled = false;
+		this.pricingBootstrapStarted = false;
 
 		// Replace debug initialization with LogService
 		const logger = createLogger('APP');
@@ -863,12 +865,12 @@ class App {
 			this.walletUI.setContext(this.ctx);
 			this.components['wallet-info'] = this.walletUI;
 
-			// Initialize wallet UI early (it's always visible, not a tab)
-			try {
-				await this.walletUI.initialize();
-			} catch (e) {
-				this.warn('WalletUI failed to initialize', e);
-			}
+			// Keep first paint focused on the shell; the wallet header can finish booting in background.
+			Promise.resolve()
+				.then(() => this.walletUI.initialize())
+				.catch((e) => {
+					this.warn('WalletUI failed to initialize', e);
+				});
 
 			// Initialize footer (persists across tabs)
 			try {
@@ -1150,7 +1152,7 @@ class App {
 
 				this.scrollActiveTabIntoView({ behavior: 'auto' });
 
-				this.scheduleOrderTabVisibilityRefresh();
+				this.scheduleOrderTabVisibilityRefresh({ force: false });
 				this.scheduleClaimTabVisibilityRefresh();
 			};
 
@@ -1164,7 +1166,7 @@ class App {
 				.then(() => this.refreshClaimTabVisibility())
 				.catch((error) => this.debug('Deferred claim visibility check failed:', error));
 			Promise.resolve()
-				.then(() => this.refreshOrderTabVisibility())
+				.then(() => this.refreshOrderTabVisibility({ force: false }))
 				.catch((error) => this.debug('Deferred order-tab visibility check failed:', error));
 
 		// Alias for legacy references in WebSocket init callbacks
@@ -1272,15 +1274,7 @@ class App {
 			this.ctx.pricing = pricingService;
 			this.ensurePricingOrderStateSubscription(pricingService);
 
-			void Promise.resolve(pricingService.initialize())
-				.then((result) => {
-					this.debug('Pricing service bootstrap complete');
-					return result;
-				})
-				.catch((error) => {
-					this.debug('Pricing service bootstrap failed:', error);
-					return false;
-				});
+			this.schedulePricingBootstrap(pricingService);
 
 			this.debug('Pricing service initialized');
 			return pricingService;
@@ -1290,6 +1284,29 @@ class App {
 		}
 	}
 
+	schedulePricingBootstrap(pricingService = this.ctx?.getPricing?.()) {
+		if (!pricingService || this.pricingBootstrapScheduled || this.pricingBootstrapStarted) {
+			return;
+		}
+
+		const startBootstrap = () => {
+			this.pricingBootstrapScheduled = false;
+			this.pricingBootstrapStarted = true;
+
+			void Promise.resolve(pricingService.initialize())
+				.then((result) => {
+					this.debug('Pricing service bootstrap complete');
+					return result;
+				})
+				.catch((error) => {
+					this.debug('Pricing service bootstrap failed:', error);
+					return false;
+				});
+		};
+
+		this.pricingBootstrapScheduled = true;
+		setTimeout(startBootstrap, 0);
+	}
 	async initializeWebSocket() {
 		try {
 			this.debug('Initializing WebSocket...');
@@ -1699,8 +1716,12 @@ window.getToast = getToast; // Keep for external/debug access if needed
 document.addEventListener('DOMContentLoaded', async () => {
 	window.app.showGlobalLoader('Checking for updates...');
 	try {
-		// Check version first, before anything else happens
-		await versionService.initialize();
+		// Avoid blocking first paint on version checks; a detected update can still trigger reload.
+		Promise.resolve()
+			.then(() => versionService.initialize())
+			.catch((error) => {
+				window.app.debug('Deferred version initialization failed:', error);
+			});
 
 		await window.app.load();
 

--- a/js/components/CreateOrder.js
+++ b/js/components/CreateOrder.js
@@ -4,7 +4,7 @@ import { getNetworkConfig } from '../config/networks.js';
 import { walletManager } from '../services/WalletManager.js';
 import { setVisibility } from '../utils/ui.js';
 import { erc20Abi } from '../abi/erc20.js';
-import { getAllWalletTokens, getContractAllowedTokens, clearTokenCaches } from '../utils/contractTokens.js';
+import { hydrateAllowedTokenBalances, getContractAllowedTokens, clearTokenCaches } from '../utils/contractTokens.js';
 import { contractService } from '../services/ContractService.js';
 import { createLogger } from '../services/LogService.js';
 import { validateSellBalance } from '../utils/balanceValidation.js';
@@ -21,6 +21,8 @@ import { buildTokenDisplaySymbolMap, getDisplaySymbol } from '../utils/tokenDisp
 
 const CREATE_ORDER_RELOAD_STATE_KEY = 'whaleswap:create-order:reload-state:v1';
 const CREATE_ORDER_RELOAD_STATE_MAX_AGE_MS = 5 * 60 * 1000;
+const CREATE_ORDER_ALLOWED_TOKENS_CACHE_KEY = 'whaleswap:create-order:allowed-tokens:v1';
+const CREATE_ORDER_ALLOWED_TOKENS_CACHE_MAX_AGE_MS = 2 * 60 * 1000;
 
 export class CreateOrder extends BaseComponent {
     constructor() {
@@ -46,6 +48,7 @@ export class CreateOrder extends BaseComponent {
         this.contractDisabledHandler = null;
         this.pendingFeeConfigRefresh = false;
         this.pendingAllowedTokensRefresh = false;
+        this.allowedTokensHydratedFromCache = false;
         this.sellToken = null;
         this.buyToken = null;
         this.isContractDisabled = false;
@@ -139,6 +142,7 @@ export class CreateOrder extends BaseComponent {
         this.feeLoadPromise = null;
         this.pendingFeeConfigRefresh = false;
         this.pendingAllowedTokensRefresh = false;
+        this.allowedTokensHydratedFromCache = false;
         this.feeToken = null;
         this.isContractDisabled = false;
         this.contractStateReadError = false;
@@ -239,6 +243,130 @@ export class CreateOrder extends BaseComponent {
         } catch (error) {
             this.debug('Unable to clear pending create-order reload state:', error);
         }
+    }
+
+    getAllowedTokensCacheContext() {
+        const selectedChainSlug = this.ctx?.getSelectedChainSlug?.() || getNetworkConfig()?.slug || null;
+        const accountAddress = this.ctx?.getWallet?.()?.getAccount?.() || null;
+
+        return {
+            selectedChainSlug,
+            accountAddress: accountAddress ? accountAddress.toLowerCase() : null
+        };
+    }
+
+    persistAllowedTokensCache(tokens = this.allowedTokens) {
+        try {
+            if (typeof window === 'undefined' || !window.sessionStorage) {
+                return false;
+            }
+
+            if (!Array.isArray(tokens) || tokens.length === 0) {
+                window.sessionStorage.removeItem(CREATE_ORDER_ALLOWED_TOKENS_CACHE_KEY);
+                return false;
+            }
+
+            const { selectedChainSlug, accountAddress } = this.getAllowedTokensCacheContext();
+            const snapshot = {
+                savedAt: Date.now(),
+                selectedChainSlug,
+                accountAddress,
+                tokens: tokens.map((token) => ({
+                    address: token?.address || '',
+                    symbol: token?.symbol || '',
+                    displaySymbol: token?.displaySymbol || token?.symbol || '',
+                    name: token?.name || '',
+                    decimals: Number.isFinite(Number(token?.decimals)) ? Number(token.decimals) : 18,
+                    balance: token?.balance ?? '0',
+                    balanceLoading: Boolean(token?.balanceLoading),
+                    iconUrl: token?.iconUrl ?? null
+                })).filter((token) => token.address)
+            };
+
+            window.sessionStorage.setItem(CREATE_ORDER_ALLOWED_TOKENS_CACHE_KEY, JSON.stringify(snapshot));
+            return true;
+        } catch (error) {
+            this.debug('Unable to persist allowed-token cache:', error);
+            return false;
+        }
+    }
+
+    readAllowedTokensCache() {
+        try {
+            if (typeof window === 'undefined' || !window.sessionStorage) {
+                return null;
+            }
+
+            const raw = window.sessionStorage.getItem(CREATE_ORDER_ALLOWED_TOKENS_CACHE_KEY);
+            if (!raw) {
+                return null;
+            }
+
+            const parsed = JSON.parse(raw);
+            const savedAt = Number(parsed?.savedAt || 0);
+            if (!savedAt || (Date.now() - savedAt) > CREATE_ORDER_ALLOWED_TOKENS_CACHE_MAX_AGE_MS) {
+                window.sessionStorage.removeItem(CREATE_ORDER_ALLOWED_TOKENS_CACHE_KEY);
+                return null;
+            }
+
+            const currentContext = this.getAllowedTokensCacheContext();
+            if (
+                parsed?.selectedChainSlug !== currentContext.selectedChainSlug
+                || (parsed?.accountAddress || null) !== currentContext.accountAddress
+            ) {
+                return null;
+            }
+
+            if (!Array.isArray(parsed?.tokens) || parsed.tokens.length === 0) {
+                return null;
+            }
+
+            return parsed.tokens;
+        } catch (error) {
+            this.debug('Unable to read allowed-token cache:', error);
+            try {
+                window.sessionStorage?.removeItem?.(CREATE_ORDER_ALLOWED_TOKENS_CACHE_KEY);
+            } catch (_) {}
+            return null;
+        }
+    }
+
+    renderAllowedTokensIntoModals(tokens = this.allowedTokens) {
+        ['sell', 'buy'].forEach(type => {
+            const modal = document.getElementById(`${type}TokenModal`);
+            if (!modal) {
+                this.debug(`No modal found for ${type}`);
+                return;
+            }
+
+            const allowedTokensList = modal.querySelector(`#${type}AllowedTokenList`);
+            if (allowedTokensList) {
+                this.displayTokens(tokens, allowedTokensList, type);
+            }
+        });
+    }
+
+    hydrateAllowedTokensFromCache() {
+        if (Array.isArray(this.allowedTokens) && this.allowedTokens.length > 0) {
+            return false;
+        }
+
+        const cachedTokens = this.readAllowedTokensCache();
+        if (!cachedTokens) {
+            return false;
+        }
+
+        this.tokenDisplaySymbolMap = buildTokenDisplaySymbolMap(
+            cachedTokens,
+            this.ctx?.getWalletChainId?.()
+        );
+        const normalizedAllowed = cachedTokens.map(token => this.normalizeTokenDisplay(token));
+        this.tokens = normalizedAllowed;
+        this.allowedTokens = normalizedAllowed;
+        this.allowedTokensHydratedFromCache = true;
+        this.renderAllowedTokensIntoModals(normalizedAllowed);
+        this.debug('Hydrated allowed tokens from session cache');
+        return true;
     }
 
     setTakerExpanded(isExpanded) {
@@ -448,7 +576,9 @@ export class CreateOrder extends BaseComponent {
                 this.populateTokenDropdowns();
             }
             if (!Array.isArray(this.allowedTokens) || this.allowedTokens.length === 0) {
-                this.setAllowedTokenListsLoadingState('Loading allowed tokens...');
+                if (!this.hydrateAllowedTokensFromCache()) {
+                    this.setAllowedTokenListsLoadingState('Loading allowed tokens...');
+                }
             }
             this.setupCreateOrderListener();
 
@@ -582,9 +712,11 @@ export class CreateOrder extends BaseComponent {
 
     requestAllowedTokensRefresh({ forceFresh = false, source = 'unknown' } = {}) {
         const hasAllowedTokens = Array.isArray(this.allowedTokens) && this.allowedTokens.length > 0;
+        const shouldRefreshHydratedCache = !forceFresh && hasAllowedTokens && this.allowedTokensHydratedFromCache;
         if (forceFresh) {
             this.tokens = [];
             this.allowedTokens = [];
+            this.allowedTokensHydratedFromCache = false;
         }
 
         if (this.allowedTokensLoadPromise) {
@@ -594,12 +726,14 @@ export class CreateOrder extends BaseComponent {
             return this.allowedTokensLoadPromise;
         }
 
-        if (!forceFresh && hasAllowedTokens) {
+        if (!forceFresh && hasAllowedTokens && !shouldRefreshHydratedCache) {
             return Promise.resolve(this.allowedTokens);
         }
 
         this.tokensLoading = true;
-        this.setAllowedTokenListsLoadingState('Loading allowed tokens...');
+        if (!hasAllowedTokens || forceFresh) {
+            this.setAllowedTokenListsLoadingState('Loading allowed tokens...');
+        }
         this.allowedTokensLoadPromise = this.loadContractTokens()
             .catch((error) => {
                 this.debug(`Allowed token refresh failed (${source}):`, error);
@@ -744,6 +878,11 @@ export class CreateOrder extends BaseComponent {
             return 'loading...';
         }
 
+        const numericBalance = Number(balance) || 0;
+        if (numericBalance <= 0) {
+            return '$0.00';
+        }
+
         const pricing = this.ctx.getPricing();
         if (pricing?.shouldShowPriceLoading?.(tokenAddress)) {
             return 'loading...';
@@ -754,7 +893,7 @@ export class CreateOrder extends BaseComponent {
             return 'N/A';
         }
 
-        const usdValue = (Number(balance) || 0) * usdPrice;
+        const usdValue = numericBalance * usdPrice;
         return usdValue.toLocaleString(undefined, {
             style: 'currency',
             currency: 'USD',
@@ -763,20 +902,40 @@ export class CreateOrder extends BaseComponent {
         });
     }
 
+    formatBalanceChipUsdValue(balanceUSD) {
+        const normalizedValue = typeof balanceUSD === 'string'
+            ? balanceUSD.trim()
+            : '';
+
+        if (!normalizedValue) {
+            return '• N/A';
+        }
+
+        if (normalizedValue === 'loading...' || normalizedValue === 'N/A') {
+            return `• ${normalizedValue}`;
+        }
+
+        return normalizedValue.startsWith('$')
+            ? `• ${normalizedValue}`
+            : `• $${normalizedValue}`;
+    }
+
     refreshAllowedTokenBalancesInBackground() {
         if (this.allowedTokensBalanceLoadPromise) {
             return this.allowedTokensBalanceLoadPromise;
         }
 
-        this.allowedTokensBalanceLoadPromise = getAllWalletTokens()
+        this.allowedTokensBalanceLoadPromise = hydrateAllowedTokenBalances(this.allowedTokens)
             .then((allowedTokens) => {
-                const normalizedAllowed = allowedTokens.map(token => this.normalizeTokenDisplay(token));
-                this.tokens = normalizedAllowed;
-                this.allowedTokens = normalizedAllowed;
-                this.syncSelectedTokensWithAllowedList();
-                this.refreshTokenModalLists();
-                return normalizedAllowed;
-            })
+            const normalizedAllowed = allowedTokens.map(token => this.normalizeTokenDisplay(token));
+            this.tokens = normalizedAllowed;
+            this.allowedTokens = normalizedAllowed;
+            this.allowedTokensHydratedFromCache = false;
+            this.syncSelectedTokensWithAllowedList();
+            this.refreshTokenModalLists();
+            this.persistAllowedTokensCache(normalizedAllowed);
+            return normalizedAllowed;
+        })
             .catch((error) => {
                 this.debug('Error fetching allowed token balances:', error);
                 return this.allowedTokens;
@@ -817,11 +976,7 @@ export class CreateOrder extends BaseComponent {
             }
 
             const balance = Number(updatedToken.balance) || 0;
-            const pricing = this.ctx.getPricing();
-            const usdPrice = pricing?.getPrice(updatedToken.address);
-            const balanceUsd = usdPrice !== undefined
-                ? (balance * usdPrice).toFixed(2)
-                : 'N/A';
+            const balanceUsd = this.formatTokenListUsdValue(updatedToken.address, balance);
 
             this.updateBalanceDisplay(
                 type,
@@ -996,7 +1151,7 @@ export class CreateOrder extends BaseComponent {
             if (balanceDisplay && balanceAmount && balanceUSDElement) {
                 // Update the balance values
                 balanceAmount.textContent = formattedBalance;
-                balanceUSDElement.textContent = `• $${balanceUSD}`;
+                balanceUSDElement.textContent = this.formatBalanceChipUsdValue(balanceUSD);
                 
                 // Show the balance display without layout shift
                 setVisibility(balanceDisplay, true);
@@ -1007,7 +1162,7 @@ export class CreateOrder extends BaseComponent {
                     balanceBtn.setAttribute('aria-label', `Click to fill ${type} amount with available balance: ${formattedBalance}`);
                 }
                 
-                this.debug(`Updated ${type} balance display: ${formattedBalance} ($${balanceUSD})`);
+                this.debug(`Updated ${type} balance display: ${formattedBalance} (${balanceUSD})`);
             }
         } catch (error) {
             this.error(`Error updating ${type} balance display:`, error);
@@ -1650,6 +1805,7 @@ export class CreateOrder extends BaseComponent {
 
             this.tokens = normalizedAllowed; // Keep allowed tokens for backward compatibility
             this.allowedTokens = normalizedAllowed;
+            this.allowedTokensHydratedFromCache = false;
             
             this.debug('Loaded allowed tokens:', normalizedAllowed);
             await this.reconcileSelectedTokensWithAllowedList();
@@ -1676,19 +1832,8 @@ export class CreateOrder extends BaseComponent {
                 this.debug(`Token ${token.symbol} has iconUrl: ${!!token.iconUrl}`, token.iconUrl);
             }
 
-            ['sell', 'buy'].forEach(type => {
-                const modal = document.getElementById(`${type}TokenModal`);
-                if (!modal) {
-                    this.debug(`No modal found for ${type}`);
-                    return;
-                }
-
-                // Display allowed tokens
-                const allowedTokensList = modal.querySelector(`#${type}AllowedTokenList`);
-                if (allowedTokensList) {
-                    this.displayTokens(normalizedAllowed, allowedTokensList, type);
-                }
-            });
+            this.renderAllowedTokensIntoModals(normalizedAllowed);
+            this.persistAllowedTokensCache(normalizedAllowed);
         } catch (error) {
             this.debug('Error loading wallet tokens:', error);
             this.setAllowedTokenListsErrorState('Failed to load allowed tokens. Please retry shortly.');

--- a/js/utils/contractTokens.js
+++ b/js/utils/contractTokens.js
@@ -258,6 +258,53 @@ export async function getContractAllowedTokens(options = {}) {
 }
 
 /**
+ * Hydrate an existing allowed-token list with wallet balances only.
+ * Reuses the current token metadata instead of re-fetching the full token payload.
+ * @param {Array} tokens - Existing token objects
+ * @returns {Promise<Array>} Tokens with refreshed balances
+ */
+export async function hydrateAllowedTokenBalances(tokens = []) {
+    try {
+        if (!Array.isArray(tokens) || tokens.length === 0) {
+            return [];
+        }
+
+        const tokenAddresses = tokens
+            .map((token) => token?.address)
+            .filter(Boolean);
+
+        if (tokenAddresses.length === 0) {
+            return tokens.map((token) => ({
+                ...token,
+                balance: token?.balance ?? '0',
+                balanceLoading: false
+            }));
+        }
+
+        const userAddress = await contractService.getUserAddress();
+        const balanceMap = await getBatchTokenBalances(tokenAddresses, userAddress);
+
+        return tokens.map((token) => {
+            const address = String(token?.address || '').toLowerCase();
+            const balance = balanceMap.get(address)?.formatted || '0';
+
+            return {
+                ...token,
+                balance,
+                balanceLoading: false
+            };
+        });
+    } catch (err) {
+        error('Failed to hydrate allowed token balances:', err);
+        return tokens.map((token) => ({
+            ...token,
+            balance: token?.balance ?? '0',
+            balanceLoading: false
+        }));
+    }
+}
+
+/**
  * Get token metadata (symbol, name, decimals)
  * @param {string} tokenAddress - The token address
  * @returns {Promise<Object>} Token metadata

--- a/tests/createOrder.displaySymbol.test.js
+++ b/tests/createOrder.displaySymbol.test.js
@@ -145,4 +145,36 @@ describe('CreateOrder display symbol wiring', () => {
         expect(document.getElementById('buyTokenSelector')?.textContent).not.toContain('AAA.issuer');
         expect(document.getElementById('buyToken')?.value).toBe('');
     });
+
+    it('formats balance chip USD text without duplicating the dollar sign', () => {
+        const component = createComponent();
+
+        document.body.insertAdjacentHTML('beforeend', `
+            <button id="sellTokenBalanceBtn" type="button"></button>
+            <div id="sellTokenBalanceDisplay"></div>
+            <div id="sellTokenBalanceAmount"></div>
+            <div id="sellTokenBalanceUSD"></div>
+        `);
+
+        component.updateBalanceDisplay('sell', '1.25', '$3.50');
+        expect(document.getElementById('sellTokenBalanceUSD')?.textContent).toBe('• $3.50');
+
+        component.updateBalanceDisplay('sell', 'loading...', 'loading...');
+        expect(document.getElementById('sellTokenBalanceUSD')?.textContent).toBe('• loading...');
+    });
+
+    it('returns $0.00 immediately for zero balances even while price loading is pending', () => {
+        const component = createComponent();
+        component.setContext({
+            ...createContextStub(),
+            getPricing: () => ({
+                shouldShowPriceLoading: () => true,
+                getPrice: () => undefined,
+                isPriceEstimated: () => false,
+                fetchPricesForTokens: async () => {}
+            })
+        });
+
+        expect(component.formatTokenListUsdValue(TOKEN_A, '0')).toBe('$0.00');
+    });
 });


### PR DESCRIPTION
## Stack
- Previous: #85
- Next: #87

## Summary
- restore cached allowed-token state on reload so CreateOrder is interactive sooner
- hydrate balances in the background and keep the selected token state in sync
- include the app-side bootstrap changes needed for the cache-driven refresh path

## Testing
- npm test