### PR TITLE
[Stack 4/5] Speed up CreateOrder cold-start token hydration

### DIFF
--- a/js/components/CreateOrder.js
+++ b/js/components/CreateOrder.js
@@ -279,7 +279,8 @@ export class CreateOrder extends BaseComponent {
                     decimals: Number.isFinite(Number(token?.decimals)) ? Number(token.decimals) : 18,
                     balance: token?.balance ?? '0',
                     balanceLoading: Boolean(token?.balanceLoading),
-                    iconUrl: token?.iconUrl ?? null
+                    iconUrl: token?.iconUrl ?? null,
+                    lastKnownUsdDisplay: this.getPersistableTokenUsdDisplay(token)
                 })).filter((token) => token.address)
             };
 
@@ -581,6 +582,7 @@ export class CreateOrder extends BaseComponent {
                 }
             }
             this.setupCreateOrderListener();
+            this.startInitialTokenDataLoading();
 
             // Initialize token selectors
             this.initializeTokenSelectors();
@@ -708,6 +710,16 @@ export class CreateOrder extends BaseComponent {
         }
 
         this.requestAllowedTokensRefresh({ source: 'background' });
+    }
+
+    startInitialTokenDataLoading() {
+        try {
+            // Allowed-token reads are HTTP-backed, so they do not need to wait for WebSocket readiness.
+            contractService.initialize();
+            void this.requestAllowedTokensRefresh({ source: 'initial-render' });
+        } catch (error) {
+            this.debug('Unable to start initial allowed-token load:', error);
+        }
     }
 
     requestAllowedTokensRefresh({ forceFresh = false, source = 'unknown' } = {}) {
@@ -856,12 +868,20 @@ export class CreateOrder extends BaseComponent {
         pricing.subscribe(this.pricingUpdatedHandler);
     }
 
+    hasTokenBalanceValue(token) {
+        return token?.balance !== null && token?.balance !== undefined && token?.balance !== '';
+    }
+
     isTokenBalanceLoading(token) {
         return Boolean(token?.balanceLoading);
     }
 
+    shouldShowTokenBalanceLoading(token) {
+        return this.isTokenBalanceLoading(token) && !this.hasTokenBalanceValue(token);
+    }
+
     formatTokenListBalanceValue(token) {
-        if (this.isTokenBalanceLoading(token)) {
+        if (this.shouldShowTokenBalanceLoading(token)) {
             return 'loading...';
         }
 
@@ -873,9 +893,12 @@ export class CreateOrder extends BaseComponent {
         });
     }
 
-    formatTokenListUsdValue(tokenAddress, balance, { isBalanceLoading = false } = {}) {
+    formatTokenListUsdValue(tokenAddress, balance, {
+        isBalanceLoading = false,
+        fallbackDisplayValue = null
+    } = {}) {
         if (isBalanceLoading) {
-            return 'loading...';
+            return fallbackDisplayValue || 'loading...';
         }
 
         const numericBalance = Number(balance) || 0;
@@ -885,12 +908,12 @@ export class CreateOrder extends BaseComponent {
 
         const pricing = this.ctx.getPricing();
         if (pricing?.shouldShowPriceLoading?.(tokenAddress)) {
-            return 'loading...';
+            return fallbackDisplayValue || 'loading...';
         }
 
         const usdPrice = pricing?.getPrice(tokenAddress);
         if (usdPrice === undefined) {
-            return 'N/A';
+            return fallbackDisplayValue || 'N/A';
         }
 
         const usdValue = numericBalance * usdPrice;
@@ -900,6 +923,40 @@ export class CreateOrder extends BaseComponent {
             minimumFractionDigits: 2,
             maximumFractionDigits: 2
         });
+    }
+
+    getPersistableTokenUsdDisplay(token) {
+        if (!token || typeof token !== 'object') {
+            return null;
+        }
+
+        const displayValue = this.formatTokenListUsdValue(token.address, token.balance, {
+            isBalanceLoading: this.shouldShowTokenBalanceLoading(token),
+            fallbackDisplayValue: token?.lastKnownUsdDisplay || null
+        });
+
+        if (displayValue === 'loading...' || displayValue === 'N/A') {
+            return token?.lastKnownUsdDisplay || null;
+        }
+
+        return displayValue;
+    }
+
+    mergeHydratingTokenState(token, previousToken) {
+        if (!previousToken || !token?.balanceLoading) {
+            return token;
+        }
+
+        const mergedToken = { ...token };
+        if (this.hasTokenBalanceValue(previousToken)) {
+            mergedToken.balance = previousToken.balance;
+        }
+
+        if (previousToken.lastKnownUsdDisplay) {
+            mergedToken.lastKnownUsdDisplay = previousToken.lastKnownUsdDisplay;
+        }
+
+        return mergedToken;
     }
 
     formatBalanceChipUsdValue(balanceUSD) {
@@ -967,8 +1024,8 @@ export class CreateOrder extends BaseComponent {
                 displaySymbol: updatedToken.displaySymbol || selectedToken.displaySymbol || updatedToken.symbol
             };
 
-            if (type !== 'sell' || this.isTokenBalanceLoading(updatedToken)) {
-                if (type === 'sell' && this.isTokenBalanceLoading(updatedToken)) {
+            if (type !== 'sell' || this.shouldShowTokenBalanceLoading(updatedToken)) {
+                if (type === 'sell' && this.shouldShowTokenBalanceLoading(updatedToken)) {
                     this.updateBalanceDisplay(type, 'loading...', 'loading...');
                 }
                 this.updateTokenAmounts(type);
@@ -976,7 +1033,9 @@ export class CreateOrder extends BaseComponent {
             }
 
             const balance = Number(updatedToken.balance) || 0;
-            const balanceUsd = this.formatTokenListUsdValue(updatedToken.address, balance);
+            const balanceUsd = this.formatTokenListUsdValue(updatedToken.address, balance, {
+                fallbackDisplayValue: updatedToken.lastKnownUsdDisplay || selectedToken.lastKnownUsdDisplay || null
+            });
 
             this.updateBalanceDisplay(
                 type,
@@ -1797,11 +1856,19 @@ export class CreateOrder extends BaseComponent {
         try {
             this.debug('Loading allowed wallet tokens...');
             const allowedTokens = await getContractAllowedTokens({ includeBalances: false });
+            const previousTokensByAddress = new Map(
+                (Array.isArray(this.allowedTokens) ? this.allowedTokens : [])
+                    .map((token) => [String(token?.address || '').toLowerCase(), token])
+                    .filter(([address]) => Boolean(address))
+            );
             this.tokenDisplaySymbolMap = buildTokenDisplaySymbolMap(
                 allowedTokens,
                 this.ctx?.getWalletChainId?.()
             );
-            const normalizedAllowed = allowedTokens.map(token => this.normalizeTokenDisplay(token));
+            const normalizedAllowed = allowedTokens.map((token) => {
+                const previousToken = previousTokensByAddress.get(String(token?.address || '').toLowerCase());
+                return this.normalizeTokenDisplay(this.mergeHydratingTokenState(token, previousToken));
+            });
 
             this.tokens = normalizedAllowed; // Keep allowed tokens for backward compatibility
             this.allowedTokens = normalizedAllowed;
@@ -2198,11 +2265,12 @@ export class CreateOrder extends BaseComponent {
                             <h4>Search Results</h4>
                             <div class="token-list">
                                 ${searchResults.map(token => {
-                                    const isBalanceLoading = this.isTokenBalanceLoading(token);
+                                    const isBalanceLoading = this.shouldShowTokenBalanceLoading(token);
                                     const balance = Number(token.balance) || 0;
                                     const formattedBalance = this.formatTokenListBalanceValue(token);
                                     const formattedUsdValue = this.formatTokenListUsdValue(token.address, balance, {
-                                        isBalanceLoading
+                                        isBalanceLoading,
+                                        fallbackDisplayValue: token.lastKnownUsdDisplay || null
                                     });
 
                                     return `
@@ -2312,7 +2380,7 @@ export class CreateOrder extends BaseComponent {
         // Add each token to the container
         sortedTokens.forEach(token => {
             const tokenElement = document.createElement('div');
-            const isBalanceLoading = this.isTokenBalanceLoading(token);
+            const isBalanceLoading = this.shouldShowTokenBalanceLoading(token);
             const balance = Number(token.balance) || 0;
             const hasBalance = !isBalanceLoading && balance > 0;
             const tokenLabel = token.displaySymbol || token.symbol;
@@ -2330,7 +2398,8 @@ export class CreateOrder extends BaseComponent {
             
             const formattedBalance = this.formatTokenListBalanceValue(token);
             const formattedUsdValue = this.formatTokenListUsdValue(token.address, balance, {
-                isBalanceLoading
+                isBalanceLoading,
+                fallbackDisplayValue: token.lastKnownUsdDisplay || null
             });
 
             // Generate background color for fallback icon
@@ -2398,9 +2467,9 @@ export class CreateOrder extends BaseComponent {
         });
 
         // Add summary information
-        const balancesLoading = sortedTokens.some(token => this.isTokenBalanceLoading(token));
+        const balancesLoading = sortedTokens.some(token => this.shouldShowTokenBalanceLoading(token));
         const tokensWithBalance = sortedTokens.filter(
-            token => !this.isTokenBalanceLoading(token) && Number(token.balance) > 0
+            token => !this.shouldShowTokenBalanceLoading(token) && Number(token.balance) > 0
         ).length;
         const totalTokens = sortedTokens.length;
         
@@ -2743,9 +2812,12 @@ export class CreateOrder extends BaseComponent {
                         });
                 }
             }
-            const isBalanceLoading = this.isTokenBalanceLoading(token);
+            const isBalanceLoading = this.shouldShowTokenBalanceLoading(token);
             const balance = parseFloat(token.balance) || 0;
-            const balanceUSD = this.formatTokenListUsdValue(token.address, balance, { isBalanceLoading });
+            const balanceUSD = this.formatTokenListUsdValue(token.address, balance, {
+                isBalanceLoading,
+                fallbackDisplayValue: token.lastKnownUsdDisplay || null
+            });
             const formattedBalance = this.formatTokenListBalanceValue(token);
             
             // Store token in the component
@@ -2755,7 +2827,8 @@ export class CreateOrder extends BaseComponent {
                 displaySymbol: token.displaySymbol || token.symbol,
                 decimals: token.decimals || 18,
                 balance: token.balance || '0',
-                balanceLoading: isBalanceLoading,
+                balanceLoading: this.isTokenBalanceLoading(token),
+                lastKnownUsdDisplay: token.lastKnownUsdDisplay || null,
                 usdPrice: usdPrice
             };
 
@@ -2872,7 +2945,7 @@ export class CreateOrder extends BaseComponent {
 
             // For sell tokens, check if balance is zero
             if (type === 'sell') {
-                if (this.isTokenBalanceLoading(token)) {
+                if (this.shouldShowTokenBalanceLoading(token)) {
                     this.showWarning('Balance is still loading for this token. Please try again in a moment.');
                     return;
                 }

--- a/js/services/MulticallService.js
+++ b/js/services/MulticallService.js
@@ -1,6 +1,5 @@
 import { ethers } from 'ethers';
 import { getNetworkConfig } from '../config/networks.js';
-import { contractService } from './ContractService.js';
 import { createLogger } from './LogService.js';
 
 // Logger (behind DEBUG_CONFIG via LogService)
@@ -13,30 +12,46 @@ const MULTICALL2_ABI = [
 	'function tryAggregate(bool requireSuccess, tuple(address target, bytes callData)[] calls) view returns (tuple(bool success, bytes returnData)[])'
 ];
 
-/**
- * Get a Multicall2 contract instance for the current network
- * Returns null if provider or multicall address is not available
- */
-function getMulticallContract() {
-	try {
-		const networkCfg = getNetworkConfig();
-		const multicallAddress = networkCfg.multicallAddress;
-		if (!multicallAddress) {
-			debug('No multicallAddress configured for current network');
-			return null;
-		}
+const httpProviderCache = new Map();
 
-		const provider = contractService.getProvider();
-		if (!provider) {
-			debug('No provider available for Multicall');
-			return null;
-		}
+function getRpcUrls() {
+	const networkCfg = getNetworkConfig();
+	return [...new Set([
+		networkCfg?.rpcUrl,
+		...(networkCfg?.fallbackRpcUrls || [])
+	].filter(Boolean))];
+}
 
-		return new ethers.Contract(multicallAddress, MULTICALL2_ABI, provider);
-	} catch (e) {
-		error('Failed to create Multicall contract:', e);
+function getHttpProvider(url) {
+	if (!url) {
 		return null;
 	}
+
+	if (!httpProviderCache.has(url)) {
+		httpProviderCache.set(url, new ethers.providers.JsonRpcProvider(url));
+	}
+
+	return httpProviderCache.get(url);
+}
+
+export async function readViaRpcProviders(readFn) {
+	const rpcUrls = getRpcUrls();
+	if (rpcUrls.length === 0) {
+		throw new Error('No HTTP RPC URL configured for current network');
+	}
+
+	let lastError = null;
+	for (const url of rpcUrls) {
+		try {
+			return await readFn(getHttpProvider(url), url);
+		} catch (e) {
+			lastError = e;
+			httpProviderCache.delete(url);
+			debug(`HTTP RPC read failed (${url}), trying next provider:`, e?.message || e);
+		}
+	}
+
+	throw lastError || new Error('All HTTP RPC URLs failed');
 }
 
 /**
@@ -47,15 +62,22 @@ function getMulticallContract() {
  */
 export async function tryAggregate(calls, options = {}) {
 	const requireSuccess = options.requireSuccess === true;
-	const mc = getMulticallContract();
-	if (!mc) return null; // Signal to fallback
+	const networkCfg = getNetworkConfig();
+	const multicallAddress = networkCfg.multicallAddress;
+	if (!multicallAddress) {
+		debug('No multicallAddress configured for current network');
+		return null;
+	}
 
 	if (!Array.isArray(calls) || calls.length === 0) {
 		return [];
 	}
 
 	try {
-		return await mc.tryAggregate(requireSuccess, calls);
+		return await readViaRpcProviders(async (provider) => {
+			const multicallContract = new ethers.Contract(multicallAddress, MULTICALL2_ABI, provider);
+			return await multicallContract.tryAggregate(requireSuccess, calls);
+		});
 	} catch (e) {
 		debug('Multicall tryAggregate failed, will fallback to per-call path:', e?.message || e);
 		return null;
@@ -68,9 +90,8 @@ export async function tryAggregate(calls, options = {}) {
 export function isMulticallAvailable() {
 	try {
 		const networkCfg = getNetworkConfig();
-		return !!(networkCfg.multicallAddress && contractService.getProvider());
+		return !!(networkCfg.multicallAddress && getRpcUrls().length > 0);
 	} catch {
 		return false;
 	}
 }
-

--- a/js/utils/contractTokens.js
+++ b/js/utils/contractTokens.js
@@ -3,7 +3,7 @@ import { getNetworkConfig } from '../config/networks.js';
 import { contractService } from '../services/ContractService.js';
 import { createLogger } from '../services/LogService.js';
 import { tokenIconService } from '../services/TokenIconService.js';
-import { tryAggregate as multicallTryAggregate } from '../services/MulticallService.js';
+import { tryAggregate as multicallTryAggregate, readViaRpcProviders } from '../services/MulticallService.js';
 import { erc20Abi } from '../abi/erc20.js';
 
 const ERC20_INTERFACE = new ethers.utils.Interface(erc20Abi);
@@ -320,8 +320,6 @@ async function getTokenMetadata(tokenAddress) {
             return cached.value;
         }
 
-        const provider = contractService.getProvider();
-
         // Prepare multicall for symbol, name, decimals (single ABI source: erc20.js)
         const calls = [
             { target: tokenAddress, callData: ERC20_INTERFACE.encodeFunctionData('symbol', []) },
@@ -338,20 +336,24 @@ async function getTokenMetadata(tokenAddress) {
                 name = ERC20_INTERFACE.decodeFunctionResult('name', mcResult[1].returnData)[0];
                 decimals = ERC20_INTERFACE.decodeFunctionResult('decimals', mcResult[2].returnData)[0];
             } catch (_) {
+                [symbol, name, decimals] = await readViaRpcProviders(async (provider) => {
+                    const tokenContract = new ethers.Contract(tokenAddress, erc20Abi, provider);
+                    return await Promise.all([
+                        tokenContract.symbol(),
+                        tokenContract.name(),
+                        tokenContract.decimals()
+                    ]);
+                });
+            }
+        } else {
+            [symbol, name, decimals] = await readViaRpcProviders(async (provider) => {
                 const tokenContract = new ethers.Contract(tokenAddress, erc20Abi, provider);
-                [symbol, name, decimals] = await Promise.all([
+                return await Promise.all([
                     tokenContract.symbol(),
                     tokenContract.name(),
                     tokenContract.decimals()
                 ]);
-            }
-        } else {
-            const tokenContract = new ethers.Contract(tokenAddress, erc20Abi, provider);
-            [symbol, name, decimals] = await Promise.all([
-                tokenContract.symbol(),
-                tokenContract.name(),
-                tokenContract.decimals()
-            ]);
+            });
         }
 
         const metadata = {
@@ -412,8 +414,6 @@ async function getUserTokenBalance(tokenAddress) {
             return cached.value;
         }
         
-        const provider = contractService.getProvider();
-
         // First, try multicall for decimals and balanceOf (single ABI source: erc20.js)
         const calls = [
             { target: tokenAddress, callData: ERC20_INTERFACE.encodeFunctionData('balanceOf', [userAddress]) },
@@ -426,18 +426,22 @@ async function getUserTokenBalance(tokenAddress) {
                 rawBalance = ERC20_INTERFACE.decodeFunctionResult('balanceOf', mcResult[0].returnData)[0];
                 decimals = ERC20_INTERFACE.decodeFunctionResult('decimals', mcResult[1].returnData)[0];
             } catch (_) {
+                [rawBalance, decimals] = await readViaRpcProviders(async (provider) => {
+                    const tokenContract = new ethers.Contract(tokenAddress, erc20Abi, provider);
+                    return await Promise.all([
+                        tokenContract.balanceOf(userAddress),
+                        tokenContract.decimals()
+                    ]);
+                });
+            }
+        } else {
+            [rawBalance, decimals] = await readViaRpcProviders(async (provider) => {
                 const tokenContract = new ethers.Contract(tokenAddress, erc20Abi, provider);
-                [rawBalance, decimals] = await Promise.all([
+                return await Promise.all([
                     tokenContract.balanceOf(userAddress),
                     tokenContract.decimals()
                 ]);
-            }
-        } else {
-            const tokenContract = new ethers.Contract(tokenAddress, erc20Abi, provider);
-            [rawBalance, decimals] = await Promise.all([
-                tokenContract.balanceOf(userAddress),
-                tokenContract.decimals()
-            ]);
+            });
         }
 
         const balance = ethers.utils.formatUnits(rawBalance, decimals);

--- a/tests/createOrder.displaySymbol.test.js
+++ b/tests/createOrder.displaySymbol.test.js
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { CreateOrder } from '../js/components/CreateOrder.js';
 import { buildTokenDisplaySymbolMap } from '../js/utils/tokenDisplay.js';
 import { walletManager } from '../js/services/WalletManager.js';
+import { contractService } from '../js/services/ContractService.js';
 
 const TOKEN_A = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
 const TOKEN_B = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
@@ -176,5 +177,49 @@ describe('CreateOrder display symbol wiring', () => {
         });
 
         expect(component.formatTokenListUsdValue(TOKEN_A, '0')).toBe('$0.00');
+    });
+
+    it('keeps stale cached balance text visible while hydration is pending', () => {
+        const component = createComponent();
+
+        expect(component.formatTokenListBalanceValue({
+            address: TOKEN_A,
+            balance: '2521.294',
+            balanceLoading: true
+        })).toBe('2,521.294');
+    });
+
+    it('keeps stale cached USD text visible while price hydration is pending', () => {
+        const component = createComponent();
+        component.setContext({
+            ...createContextStub(),
+            getPricing: () => ({
+                shouldShowPriceLoading: () => true,
+                getPrice: () => undefined,
+                isPriceEstimated: () => false,
+                fetchPricesForTokens: async () => {}
+            })
+        });
+
+        expect(component.formatTokenListUsdValue(TOKEN_A, '2521.294', {
+            fallbackDisplayValue: '$2,520.63'
+        })).toBe('$2,520.63');
+    });
+
+    it('starts allowed-token refresh during initial render before websocket bootstrap completes', async () => {
+        const component = createComponent();
+        const initializeContractService = vi.spyOn(contractService, 'initialize').mockImplementation(() => {});
+        const requestAllowedTokensRefresh = vi.spyOn(component, 'requestAllowedTokensRefresh').mockReturnValue(Promise.resolve([]));
+        vi.spyOn(component, 'bootstrapWebSocketData').mockReturnValue(new Promise(() => {}));
+        vi.spyOn(component, 'populateTokenDropdowns').mockImplementation(() => {});
+        vi.spyOn(component, 'setupCreateOrderListener').mockImplementation(() => {});
+        vi.spyOn(component, 'initializeTokenSelectors').mockImplementation(() => {});
+        vi.spyOn(component, 'initializeAmountInputs').mockImplementation(() => {});
+        vi.spyOn(component, 'hydrateAllowedTokensFromCache').mockReturnValue(false);
+
+        await component.initialize(true);
+
+        expect(initializeContractService).toHaveBeenCalled();
+        expect(requestAllowedTokensRefresh).toHaveBeenCalledWith({ source: 'initial-render' });
     });
 });


### PR DESCRIPTION
## Stack
- Previous: #86
- Next: #88

## Summary
- start CreateOrder token reads before websocket bootstrap finishes
- switch the cold-start token metadata and multicall reads to HTTP RPC providers
- keep stale balance and USD displays visible during hydration instead of flashing loading state

## Testing
- npm test