### PR TITLE
Fix XSS in token search 'no results' message

### DIFF
--- a/js/components/CreateOrder.js
+++ b/js/components/CreateOrder.js
@@ -16,6 +16,7 @@ import {
     handleTransactionError,
     isUserRejection,
 } from '../utils/ui.js';
+import { escapeHtmlText } from '../utils/html.js';
 import { getExplorerUrl } from '../utils/orderUtils.js';
 import { buildTokenDisplaySymbolMap, getDisplaySymbol } from '../utils/tokenDisplay.js';
 
@@ -2035,11 +2036,12 @@ export class CreateOrder extends BaseComponent {
                         this.renderTokenIcon(searchResults[index], iconContainer);
                     });
                 } else {
+                    const escapedSearchTerm = escapeHtmlText(searchTerm);
                     contractResult.innerHTML = `
                         <div class="token-section">
                             <h4>Search Results</h4>
                             <div class="token-list-empty">
-                                No tokens found matching "${searchTerm}"
+                                No tokens found matching "${escapedSearchTerm}"
                             </div>
                         </div>
                     `;

--- a/tests/createOrder.displaySymbol.test.js
+++ b/tests/createOrder.displaySymbol.test.js
@@ -90,6 +90,36 @@ describe('CreateOrder display symbol wiring', () => {
         expect(resultSymbols).toEqual(['AAA.issuer']);
     });
 
+    it('renders unmatched token search text safely as plain text', async () => {
+        const component = createComponent();
+        const payload = '<img src=x onerror=alert(1)>';
+
+        component.tokens = [];
+        component.tokensLoading = false;
+
+        await component.handleTokenSearch(payload, 'sell');
+
+        const resultContainer = document.getElementById('sellContractResult');
+        const emptyState = resultContainer?.querySelector('.token-list-empty');
+
+        expect(emptyState?.textContent).toContain(payload);
+        expect(resultContainer?.querySelector('img')).toBeNull();
+        expect(resultContainer?.querySelector('script')).toBeNull();
+        expect(resultContainer?.querySelector('input')).toBeNull();
+    });
+
+    it('keeps plain unmatched token search messaging unchanged', async () => {
+        const component = createComponent();
+
+        component.tokens = [];
+        component.tokensLoading = false;
+
+        await component.handleTokenSearch('missing-token', 'sell');
+
+        expect(document.querySelector('#sellContractResult .token-list-empty')?.textContent)
+            .toContain('No tokens found matching "missing-token"');
+    });
+
     it('uses displaySymbol in zero-balance warning for sell selection', async () => {
         const component = createComponent();
         const warningSpy = vi.fn();


### PR DESCRIPTION
**Summary**
- Escape user-supplied search term when rendering the "No tokens found matching …" message so pasted HTML/script is shown as plain text and not executed.
- Prevents popups and XSS via the sell/buy token search inputs (e.g. `#sellTokenSearch` / `#buyTokenSearch`).

**Changes**
- Use `escapeHtmlText()` from `utils/html.js` for the search term in `handleTokenSearch()` (`CreateOrder.js`).
- Add unit tests: safe rendering of HTML/script in unmatched search text, and unchanged plain-text messaging for normal queries.

**Ref**
- Fixes #92