### PR TITLE
Fix infinite loading for unsupported token addresses

### DIFF
--- a/css/components/forms.css
+++ b/css/components/forms.css
@@ -858,6 +858,8 @@
   font-style: italic;
   background: #f8f9fe;
   border-radius: 12px;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 /* Token section header styling */

--- a/js/components/CreateOrder.js
+++ b/js/components/CreateOrder.js
@@ -8,8 +8,6 @@ import { getAllWalletTokens, getContractAllowedTokens, clearTokenCaches } from '
 import { contractService } from '../services/ContractService.js';
 import { createLogger } from '../services/LogService.js';
 import { validateSellBalance } from '../utils/balanceValidation.js';
-import { tokenIconService } from '../services/TokenIconService.js';
-import { generateTokenIconHTML, getFallbackIconData } from '../utils/tokenIcons.js';
 import { createTransactionProgressSession } from '../utils/transactionProgress.js';
 import {
     extractTransactionErrorMessage,
@@ -1615,7 +1613,7 @@ export class CreateOrder extends BaseComponent {
                 // Display allowed tokens
                 const allowedTokensList = modal.querySelector(`#${type}AllowedTokenList`);
                 if (allowedTokensList) {
-                    this.displayTokens(normalizedAllowed, allowedTokensList, type);
+                    this.renderAllowedTokenList(type);
                 }
             });
         } catch (error) {
@@ -1774,13 +1772,16 @@ export class CreateOrder extends BaseComponent {
                 <div class="token-modal-search">
                     <input type="text" 
                            class="token-search-input" 
-                           placeholder="Search by name or paste address"
+                           placeholder="Search by name, symbol, or address"
                            id="${type}TokenSearch">
                 </div>
                 <div class="token-sections">
-                    <div id="${type}ContractResult"></div>
+                    <div id="${type}TokenResultsSection" class="token-section hidden" aria-hidden="true">
+                        <h4>Results</h4>
+                        <div class="token-list" id="${type}TokenResultsList"></div>
+                    </div>
                     <div class="token-section">
-                        <h4>Allowed tokens</h4>
+                        <h4 id="${type}TokenListHeading">Allowed tokens</h4>
                         <div class="token-list" id="${type}AllowedTokenList">
                             <div class="token-list-loading">
                                 <div class="spinner"></div>
@@ -1826,240 +1827,67 @@ export class CreateOrder extends BaseComponent {
         });
     }
 
-    async handleTokenSearch(searchTerm, type) {
+    renderAllowedTokenList(type, rawSearchTerm = null) {
+        const modal = document.getElementById(`${type}TokenModal`);
+        const allowedList = modal?.querySelector(`#${type}AllowedTokenList`);
+        const resultsSection = modal?.querySelector(`#${type}TokenResultsSection`);
+        const resultsList = modal?.querySelector(`#${type}TokenResultsList`);
+        if (!allowedList) return;
+
+        const searchInput = modal.querySelector(`#${type}TokenSearch`);
+        const searchValue = typeof rawSearchTerm === 'string'
+            ? rawSearchTerm
+            : (searchInput?.value || '');
+        const normalizedSearchTerm = searchValue.trim().toLowerCase();
+        const searchSource = Array.isArray(this.allowedTokens) ? this.allowedTokens : [];
+        this.displayTokens(searchSource, allowedList, type);
+
+        if (!normalizedSearchTerm) {
+            if (resultsSection) {
+                resultsSection.classList.add('hidden');
+                resultsSection.setAttribute('aria-hidden', 'true');
+            }
+            if (resultsList) {
+                resultsList.innerHTML = '';
+            }
+            return;
+        }
+
+        const searchResults = searchSource.filter((token) => {
+            const tokenName = (token?.name || '').toLowerCase();
+            const tokenSymbol = (token?.symbol || '').toLowerCase();
+            const displaySymbol = (token?.displaySymbol || '').toLowerCase();
+            const tokenAddress = (token?.address || '').toLowerCase();
+
+            return tokenName.includes(normalizedSearchTerm)
+                || tokenSymbol.includes(normalizedSearchTerm)
+                || displaySymbol.includes(normalizedSearchTerm)
+                || tokenAddress.includes(normalizedSearchTerm);
+        });
+
+        const emptyMessage = `No tokens found matching "${normalizedSearchTerm}"`;
+        if (resultsSection) {
+            resultsSection.classList.remove('hidden');
+            resultsSection.setAttribute('aria-hidden', 'false');
+        }
+        if (resultsList) {
+            this.displayTokens(searchResults, resultsList, type, { emptyMessage });
+        }
+    }
+
+    handleTokenSearch(searchTerm, type) {
         try {
-            const contractResult = document.getElementById(`${type}ContractResult`);
-            
-            searchTerm = searchTerm.trim().toLowerCase();
-            
-            // Clear previous contract result only
-            contractResult.innerHTML = '';
-
-            // If search is empty, just clear the contract result
-            if (!searchTerm) {
-                return;
-            }
-
-            // Check if input is an address
-            if (ethers.utils.isAddress(searchTerm)) {
-                const invalidContractMarkup = `
-                    <div class="token-section">
-                        <h4>Token Contract</h4>
-                        <div class="contract-error">
-                            Invalid or unsupported token contract
-                        </div>
-                    </div>
-                `;
-
-                // Show loading state for contract result
-                contractResult.innerHTML = `
-                    <div class="token-section">
-                        <h4>Token Contract</h4>
-                        <div class="contract-loading">
-                            <div class="spinner"></div>
-                            <span>Loading token info...</span>
-                        </div>
-                    </div>
-                `;
-
-                try {
-                    const tokenContract = new ethers.Contract(
-                        searchTerm,
-                        erc20Abi,
-                        this.provider
-                    );
-
-                    const [name, symbol, decimals, balance] = await Promise.all([
-                        tokenContract.name().catch(() => null),
-                        tokenContract.symbol().catch(() => null),
-                        tokenContract.decimals().catch(() => null),
-                        tokenContract.balanceOf(await walletManager.getCurrentAddress()).catch(() => null)
-                    ]);
-
-                    if (!name || !symbol || decimals === null) {
-                        contractResult.innerHTML = invalidContractMarkup;
-                        return;
-                    }
-
-                    // Check if token is allowed in the contract
-                    const isAllowed = await contractService.isTokenAllowed(searchTerm);
-                    if (!isAllowed) {
-                        contractResult.innerHTML = `
-                            <div class="token-section">
-                                <h4>Token Contract</h4>
-                                <div class="contract-error">
-                                    Token is not allowed for trading on this platform
-                                </div>
-                            </div>
-                        `;
-                        return;
-                    }
-                    
-                    const token = this.normalizeTokenDisplay({
-                        address: searchTerm,
-                        name,
-                        symbol,
-                        decimals,
-                        balance: balance ? ethers.utils.formatUnits(balance, decimals) : '0'
-                    });
-
-                    // Get USD price and calculate USD value
-                    const formattedUsdValue = this.formatTokenListUsdValue(token.address, token.balance);
-
-                    // Format balance
-                    const formattedBalance = Number(token.balance).toLocaleString(undefined, { 
-                        minimumFractionDigits: 2, 
-                        maximumFractionDigits: 4,
-                        useGrouping: true
-                    });
-
-                    contractResult.innerHTML = `
-                        <div class="token-section">
-                            <h4>Token Contract</h4>
-                            <div class="token-list">
-                                <div class="token-item token-allowed" data-address="${token.address}">
-                                    <div class="token-item-left">
-                                        <div class="token-icon">
-                                            <div class="loading-spinner"></div>
-                                        </div>
-                                        <div class="token-item-info">
-                                            <div class="token-item-symbol">
-                                                ${token.displaySymbol || token.symbol}
-                                            </div>
-                                            <div class="token-item-name">
-                                                ${token.name}
-                                                <a href="${getExplorerUrl(token.address)}" 
-                                                   target="_blank"
-                                                   class="token-explorer-link"
-                                                   onclick="event.stopPropagation();">
-                                                    <svg class="token-explorer-icon" viewBox="0 0 24 24">
-                                                        <path fill="currentColor" d="M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z" />
-                                                    </svg>
-                                                </a>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <div class="token-item-right">
-                                        <div class="token-balance-with-usd">
-                                            <div class="token-balance-amount">${formattedBalance}</div>
-                                            <div class="token-balance-usd">${formattedUsdValue}</div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    `;
-
-                    // Add click handler
-                    const tokenItem = contractResult.querySelector('.token-item');
-                    tokenItem.addEventListener('click', () => this.handleTokenItemClick(type, tokenItem));
-
-                    // Render token icon asynchronously
-                    const iconContainer = tokenItem.querySelector('.token-icon');
-                    this.renderTokenIcon(token, iconContainer);
-                } catch (error) {
-                    contractResult.innerHTML = invalidContractMarkup;
-                }
-            } else {
-                // Search in allowed tokens by name/symbol
-                const searchSource = Array.isArray(this.tokens) ? this.tokens : [];
-                if (this.tokensLoading && searchSource.length === 0) {
-                    contractResult.innerHTML = `
-                        <div class="token-section">
-                            <h4>Search Results</h4>
-                            <div class="token-list-loading">
-                                <div class="spinner"></div>
-                                <div>Loading allowed tokens...</div>
-                            </div>
-                        </div>
-                    `;
-                    return;
-                }
-
-                const searchResults = searchSource.filter(token => 
-                    token.name.toLowerCase().includes(searchTerm) ||
-                    token.symbol.toLowerCase().includes(searchTerm) ||
-                    (token.displaySymbol || '').toLowerCase().includes(searchTerm)
-                );
-
-                if (searchResults.length > 0) {
-                    contractResult.innerHTML = `
-                        <div class="token-section">
-                            <h4>Search Results</h4>
-                            <div class="token-list">
-                                ${searchResults.map(token => {
-                                    const isBalanceLoading = this.isTokenBalanceLoading(token);
-                                    const balance = Number(token.balance) || 0;
-                                    const formattedBalance = this.formatTokenListBalanceValue(token);
-                                    const formattedUsdValue = this.formatTokenListUsdValue(token.address, balance, {
-                                        isBalanceLoading
-                                    });
-
-                                    return `
-                                        <div class="token-item token-allowed" data-address="${token.address}">
-                                            <div class="token-item-left">
-                                                <div class="token-icon">
-                                                    <div class="loading-spinner"></div>
-                                                </div>
-                                                <div class="token-item-info">
-                                                    <div class="token-item-symbol">
-                                                        ${token.displaySymbol || token.symbol}
-                                                    </div>
-                                                    <div class="token-item-name">
-                                                        ${token.name}
-                                                        <a href="${getExplorerUrl(token.address)}" 
-                                                           target="_blank"
-                                                           class="token-explorer-link"
-                                                           onclick="event.stopPropagation();">
-                                                            <svg class="token-explorer-icon" viewBox="0 0 24 24">
-                                                                <path fill="currentColor" d="M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z" />
-                                                            </svg>
-                                                        </a>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                            <div class="token-item-right">
-                                                <div class="token-balance-with-usd">
-                                                    <div class="token-balance-amount">${formattedBalance}</div>
-                                                    <div class="token-balance-usd">${formattedUsdValue}</div>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    `;
-                                }).join('')}
-                            </div>
-                        </div>
-                    `;
-
-                    // Add click handlers for search results
-                    const tokenItems = contractResult.querySelectorAll('.token-item');
-                    tokenItems.forEach((item, index) => {
-                        item.addEventListener('click', () => this.handleTokenItemClick(type, item));
-                        
-                        // Render token icon asynchronously
-                        const iconContainer = item.querySelector('.token-icon');
-                        this.renderTokenIcon(searchResults[index], iconContainer);
-                    });
-                } else {
-                    const escapedSearchTerm = escapeHtmlText(searchTerm);
-                    contractResult.innerHTML = `
-                        <div class="token-section">
-                            <h4>Search Results</h4>
-                            <div class="token-list-empty">
-                                No tokens found matching "${escapedSearchTerm}"
-                            </div>
-                        </div>
-                    `;
-                }
-            }
+            this.renderAllowedTokenList(type, searchTerm);
         } catch (error) {
             this.debug('Search error:', error);
             this.showError('Error searching for token');
         }
     }
 
-    displayTokens(tokens, container, type) {
+    displayTokens(tokens, container, type, options = {}) {
         if (!container) return;
+
+        const { emptyMessage = null } = options;
 
         if (!tokens || tokens.length === 0) {
             if (this.tokensLoading || this.allowedTokensLoadPromise) {
@@ -2068,6 +1896,13 @@ export class CreateOrder extends BaseComponent {
                         <div class="spinner"></div>
                         <div>Loading allowed tokens...</div>
                     </div>
+                `;
+                return;
+            }
+
+            if (emptyMessage) {
+                container.innerHTML = `
+                    <div class="token-list-empty">${escapeHtmlText(emptyMessage)}</div>
                 `;
                 return;
             }
@@ -2222,58 +2057,6 @@ export class CreateOrder extends BaseComponent {
             ...token,
             displaySymbol: getDisplaySymbol(token, this.tokenDisplaySymbolMap)
         };
-    }
-
-    // Add helper method for token icons
-    async getTokenIcon(token) {
-        try {
-            this.debug(`Getting icon for token ${token.symbol} (${token.address})`);
-            this.debug(`Token object:`, token);
-            
-            // If token already has an iconUrl, use it
-            if (token.iconUrl) {
-                this.debug('Using existing iconUrl for token:', token.symbol, token.iconUrl);
-                return generateTokenIconHTML(token.iconUrl, token.symbol, token.address);
-            }
-            
-            // Otherwise, get icon URL from token icon service
-            const fallbackChainId = Number.parseInt(getNetworkConfig().chainId, 16) || 137;
-            const chainId = walletManager.chainId ? parseInt(walletManager.chainId, 16) : fallbackChainId;
-            const iconUrl = await tokenIconService.getIconUrl(token.address, chainId);
-            
-            // Generate HTML using the utility function
-            return generateTokenIconHTML(iconUrl, token.symbol, token.address);
-        } catch (error) {
-            this.debug('Error getting token icon:', error);
-            // Fallback to basic fallback icon
-            const fallbackData = getFallbackIconData(token.address, token.symbol);
-            return `
-                <div class="token-icon">
-                    <div class="token-icon-fallback" style="background: ${fallbackData.backgroundColor}">
-                        ${fallbackData.text}
-                    </div>
-                </div>
-            `;
-        }
-    }
-
-    // Helper method to render token icon asynchronously
-    async renderTokenIcon(token, container) {
-        try {
-            const iconHtml = await this.getTokenIcon(token);
-            container.innerHTML = iconHtml;
-        } catch (error) {
-            this.debug('Error rendering token icon:', error);
-            // Fallback to basic icon
-            const fallbackData = getFallbackIconData(token.address, token.symbol);
-            container.innerHTML = `
-                <div class="token-icon">
-                    <div class="token-icon-fallback" style="background: ${fallbackData.backgroundColor}">
-                        ${fallbackData.text}
-                    </div>
-                </div>
-            `;
-        }
     }
 
     cleanup() {
@@ -2845,7 +2628,7 @@ export class CreateOrder extends BaseComponent {
                     }
                     const allowedTokensList = modal.querySelector(`#${type}AllowedTokenList`);
                     if (allowedTokensList && Array.isArray(this.allowedTokens)) {
-                        this.displayTokens(this.allowedTokens, allowedTokensList, type);
+                        this.renderAllowedTokenList(type);
                     }
                     modal.style.display = 'block';
 
@@ -3164,7 +2947,7 @@ export class CreateOrder extends BaseComponent {
                 if (isOpen) {
                     const allowedTokensList = modal.querySelector(`#${type}AllowedTokenList`);
                     if (allowedTokensList && Array.isArray(this.allowedTokens)) {
-                        this.displayTokens(this.allowedTokens, allowedTokensList, type);
+                        this.renderAllowedTokenList(type);
                     }
                 }
             });
@@ -3179,7 +2962,7 @@ export class CreateOrder extends BaseComponent {
                 const modal = document.getElementById(`${type}TokenModal`);
                 const allowedTokensList = modal?.querySelector(`#${type}AllowedTokenList`);
                 if (allowedTokensList && Array.isArray(this.allowedTokens)) {
-                    this.displayTokens(this.allowedTokens, allowedTokensList, type);
+                    this.renderAllowedTokenList(type);
                 }
             });
         } catch (error) {

--- a/tests/createOrder.displaySymbol.test.js
+++ b/tests/createOrder.displaySymbol.test.js
@@ -1,8 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { ethers } from 'ethers';
 import { CreateOrder } from '../js/components/CreateOrder.js';
 import { buildTokenDisplaySymbolMap } from '../js/utils/tokenDisplay.js';
-import { contractService } from '../js/services/ContractService.js';
 import { walletManager } from '../js/services/WalletManager.js';
 
 const TOKEN_A = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
@@ -37,11 +35,37 @@ function createContextStub() {
 function createComponent() {
     document.body.innerHTML = `
         <div id="create-order"></div>
-        <div id="sellContractResult"></div>
+        <div id="sellTokenModal">
+            <input id="sellTokenSearch" value="" />
+            <div id="sellTokenResultsSection" class="token-section hidden" aria-hidden="true">
+                <h4>Results</h4>
+                <div id="sellTokenResultsList"></div>
+            </div>
+            <h4 id="sellTokenListHeading">Allowed tokens</h4>
+            <div id="sellAllowedTokenList"></div>
+        </div>
+        <div id="buyTokenModal">
+            <input id="buyTokenSearch" value="" />
+            <div id="buyTokenResultsSection" class="token-section hidden" aria-hidden="true">
+                <h4>Results</h4>
+                <div id="buyTokenResultsList"></div>
+            </div>
+            <h4 id="buyTokenListHeading">Allowed tokens</h4>
+            <div id="buyAllowedTokenList"></div>
+        </div>
     `;
     const component = new CreateOrder();
     component.setContext(createContextStub());
     return component;
+}
+
+function setAllowedTokens(component, tokens) {
+    component.tokenDisplaySymbolMap = buildTokenDisplaySymbolMap(tokens, '0x89', TEST_SUFFIXES);
+    const normalizedTokens = tokens.map((token) => component.normalizeTokenDisplay(token));
+    component.tokens = normalizedTokens;
+    component.allowedTokens = normalizedTokens;
+    component.tokensLoading = false;
+    return normalizedTokens;
 }
 
 beforeEach(() => {
@@ -78,30 +102,51 @@ describe('CreateOrder display symbol wiring', () => {
             { address: TOKEN_A, symbol: 'AAA', name: 'Alpha Issuer', balance: '1', iconUrl: 'fallback' },
             { address: TOKEN_B, symbol: 'AAA', name: 'Alpha Default', balance: '1', iconUrl: 'fallback' }
         ];
-        component.tokenDisplaySymbolMap = buildTokenDisplaySymbolMap(tokens, '0x89', TEST_SUFFIXES);
-        component.tokens = tokens.map((token) => component.normalizeTokenDisplay(token));
-        component.tokensLoading = false;
-        component.renderTokenIcon = vi.fn();
+        setAllowedTokens(component, tokens);
 
         await component.handleTokenSearch('issuer', 'sell');
 
         const resultSymbols = Array.from(
-            document.querySelectorAll('#sellContractResult .token-item-symbol')
+            document.querySelectorAll('#sellTokenResultsList .token-item-symbol')
+        ).map((element) => element.textContent.trim());
+        const allowedSymbols = Array.from(
+            document.querySelectorAll('#sellAllowedTokenList .token-item-symbol')
         ).map((element) => element.textContent.trim());
 
         expect(resultSymbols).toEqual(['AAA.issuer']);
+        expect(allowedSymbols).toEqual(['AAA', 'AAA.issuer']);
+        expect(document.getElementById('sellTokenResultsSection')?.getAttribute('aria-hidden')).toBe('false');
+    });
+
+    it('allows searching by allowed token address locally', async () => {
+        const component = createComponent();
+        const tokens = [
+            { address: TOKEN_A, symbol: 'AAA', name: 'Alpha Issuer', balance: '1', iconUrl: 'fallback' },
+            { address: TOKEN_B, symbol: 'BBB', name: 'Beta Default', balance: '1', iconUrl: 'fallback' }
+        ];
+
+        setAllowedTokens(component, tokens);
+
+        await component.handleTokenSearch(TOKEN_B, 'sell');
+
+        const resultSymbols = Array.from(
+            document.querySelectorAll('#sellTokenResultsList .token-item-symbol')
+        ).map((element) => element.textContent.trim());
+
+        expect(resultSymbols).toEqual(['BBB']);
     });
 
     it('renders unmatched token search text safely as plain text', async () => {
         const component = createComponent();
         const payload = '<img src=x onerror=alert(1)>';
 
+        component.allowedTokens = [];
         component.tokens = [];
         component.tokensLoading = false;
 
         await component.handleTokenSearch(payload, 'sell');
 
-        const resultContainer = document.getElementById('sellContractResult');
+        const resultContainer = document.getElementById('sellTokenResultsList');
         const emptyState = resultContainer?.querySelector('.token-list-empty');
 
         expect(emptyState?.textContent).toContain(payload);
@@ -113,38 +158,62 @@ describe('CreateOrder display symbol wiring', () => {
     it('keeps plain unmatched token search messaging unchanged', async () => {
         const component = createComponent();
 
+        component.allowedTokens = [];
         component.tokens = [];
         component.tokensLoading = false;
 
         await component.handleTokenSearch('missing-token', 'sell');
 
-        expect(document.querySelector('#sellContractResult .token-list-empty')?.textContent)
+        expect(document.querySelector('#sellTokenResultsList .token-list-empty')?.textContent)
             .toContain('No tokens found matching "missing-token"');
     });
 
-    it('shows invalid contract error for valid addresses with unsupported token metadata', async () => {
+    it('restores the full allowed token list when search is cleared', async () => {
         const component = createComponent();
-        const validAddress = '0x1111111111111111111111111111111111111111';
-        const unsupportedContract = {
-            name: vi.fn().mockRejectedValue(new Error('name unsupported')),
-            symbol: vi.fn().mockRejectedValue(new Error('symbol unsupported')),
-            decimals: vi.fn().mockRejectedValue(new Error('decimals unsupported')),
-            balanceOf: vi.fn().mockRejectedValue(new Error('balance unsupported'))
-        };
+        const tokens = [
+            { address: TOKEN_A, symbol: 'AAA', name: 'Alpha Issuer', balance: '1', iconUrl: 'fallback' },
+            { address: TOKEN_B, symbol: 'BBB', name: 'Beta Default', balance: '1', iconUrl: 'fallback' }
+        ];
 
-        vi.spyOn(walletManager, 'getCurrentAddress').mockResolvedValue(validAddress);
-        vi.spyOn(ethers, 'Contract').mockImplementation(() => unsupportedContract);
-        const isTokenAllowedSpy = vi.spyOn(contractService, 'isTokenAllowed');
+        setAllowedTokens(component, tokens);
 
-        await component.handleTokenSearch(validAddress, 'sell');
+        await component.handleTokenSearch('issuer', 'sell');
+        await component.handleTokenSearch('', 'sell');
 
-        const resultContainer = document.getElementById('sellContractResult');
-        const errorState = resultContainer?.querySelector('.contract-error');
+        const resultSymbols = Array.from(
+            document.querySelectorAll('#sellAllowedTokenList .token-item-symbol')
+        ).map((element) => element.textContent.trim());
 
-        expect(errorState?.textContent).toContain('Invalid or unsupported token contract');
-        expect(resultContainer?.querySelector('.contract-loading')).toBeNull();
-        expect(resultContainer?.querySelector('.token-item')).toBeNull();
-        expect(isTokenAllowedSpy).not.toHaveBeenCalled();
+        expect(resultSymbols).toEqual(['AAA.issuer', 'BBB']);
+        expect(document.getElementById('sellTokenResultsSection')?.getAttribute('aria-hidden')).toBe('true');
+        expect(document.querySelectorAll('#sellTokenResultsList .token-item-symbol')).toHaveLength(0);
+    });
+
+    it('preserves the filtered view when modal lists refresh', () => {
+        const component = createComponent();
+        const tokens = [
+            { address: TOKEN_A, symbol: 'AAA', name: 'Alpha Issuer', balance: '1', iconUrl: 'fallback' },
+            { address: TOKEN_B, symbol: 'BBB', name: 'Beta Default', balance: '1', iconUrl: 'fallback' }
+        ];
+
+        setAllowedTokens(component, tokens);
+
+        const sellModal = document.getElementById('sellTokenModal');
+        const searchInput = document.getElementById('sellTokenSearch');
+        sellModal.style.display = 'block';
+        searchInput.value = 'issuer';
+
+        component.refreshOpenTokenModals();
+
+        const resultSymbols = Array.from(
+            document.querySelectorAll('#sellTokenResultsList .token-item-symbol')
+        ).map((element) => element.textContent.trim());
+        const allowedSymbols = Array.from(
+            document.querySelectorAll('#sellAllowedTokenList .token-item-symbol')
+        ).map((element) => element.textContent.trim());
+
+        expect(resultSymbols).toEqual(['AAA.issuer']);
+        expect(allowedSymbols).toEqual(['AAA.issuer', 'BBB']);
     });
 
     it('uses displaySymbol in zero-balance warning for sell selection', async () => {


### PR DESCRIPTION
**Summary**
- Show "Invalid or unsupported token contract" when the pasted address is valid format but does not implement ERC-20 (e.g. random address). Replaces the previous infinite "Loading token info..." spinner.
- Reuse the same error markup in the `catch` block to avoid duplication.

**Changes**
- In `handleTokenSearch()`, after `Promise.all` for name/symbol/decimals/balance: if any of name, symbol, or decimals is missing, set error state and return before calling `isTokenAllowed`.
- Add unit test for valid-format address with unsupported token metadata.

**Ref**
- Fixes #91