### PR TITLE
Hide Amoy outside local development

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -2,7 +2,15 @@ import { BaseComponent } from './components/BaseComponent.js';
 import { CreateOrder } from './components/CreateOrder.js';
 import { APP_BRAND, APP_LOGO } from './config/index.js';
 import { DEBUG_CONFIG } from './config/debug.js';
-import { getNetworkConfig, getAllNetworks, getNetworkById, getNetworkBySlug, getDefaultNetwork, setActiveNetwork } from './config/networks.js';
+import {
+	getNetworkConfig,
+	getAllNetworks,
+	getNetworkById,
+	getNetworkBySlug,
+	getDefaultNetwork,
+	getRequestedNetworkSlugFromUrl,
+	setActiveNetwork
+} from './config/networks.js';
 import { walletManager } from './services/WalletManager.js';
 import { WalletUI } from './components/WalletUI.js';
 import { WebSocketService } from './services/WebSocket.js';
@@ -1760,9 +1768,7 @@ function buildNetworkOptionMarkup(network) {
 }
 
 function getChainSlugFromUrl() {
-	const params = new URLSearchParams(window.location.search);
-	const slug = params.get('chain');
-	return slug ? slug.toLowerCase() : null;
+	return getRequestedNetworkSlugFromUrl();
 }
 
 function getInitialSelectedNetwork() {

--- a/js/config/networks.js
+++ b/js/config/networks.js
@@ -9,6 +9,16 @@ const isLocalHostname = () => {
     return host === 'localhost' || host === '127.0.0.1';
 };
 
+export const getRequestedNetworkSlugFromUrl = () => {
+    if (typeof window === 'undefined' || !window.location) {
+        return null;
+    }
+
+    const params = new URLSearchParams(window.location.search || '');
+    const chainSlug = params.get('chain');
+    return chainSlug ? chainSlug.toLowerCase() : null;
+};
+
 const localNetworkConfig = {
     "1337": {
         slug: "local",
@@ -122,6 +132,9 @@ const primaryNetworkConfig = {
             "wss://polygon.api.onfinality.io/public-ws"
         ]
     },
+};
+
+const testNetworkConfig = {
     "80002": {
         slug: "amoy",
         name: "Polygon Amoy",
@@ -149,9 +162,13 @@ const primaryNetworkConfig = {
     },
 };
 
-const networkConfig = isLocalHostname()
-    ? { ...primaryNetworkConfig, ...localNetworkConfig }
-    : primaryNetworkConfig;
+const shouldIncludeAmoyNetwork = isLocalHostname() || getRequestedNetworkSlugFromUrl() === 'amoy';
+
+const networkConfig = {
+    ...primaryNetworkConfig,
+    ...(shouldIncludeAmoyNetwork ? testNetworkConfig : {}),
+    ...(isLocalHostname() ? localNetworkConfig : {})
+};
 
 const normalizeChainId = (chainId) => {
     if (chainId === null || chainId === undefined) {

--- a/tests/networks.visibility.test.js
+++ b/tests/networks.visibility.test.js
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const loadNetworksModule = async ({ hostname = 'whaleswap.finance', search = '' } = {}) => {
+    vi.resetModules();
+    vi.stubGlobal('window', {
+        location: {
+            hostname,
+            search
+        }
+    });
+
+    return import('../js/config/networks.js');
+};
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+});
+
+describe('network visibility', () => {
+    it('hides Amoy on non-local hosts without an explicit override', async () => {
+        const networks = await loadNetworksModule();
+
+        expect(networks.getAllNetworks().map((network) => network.slug)).not.toContain('amoy');
+        expect(networks.getNetworkBySlug('amoy')).toBeNull();
+    });
+
+    it('shows Amoy on localhost', async () => {
+        const networks = await loadNetworksModule({
+            hostname: 'localhost'
+        });
+
+        expect(networks.getAllNetworks().map((network) => network.slug)).toContain('amoy');
+        expect(networks.getNetworkBySlug('amoy')?.slug).toBe('amoy');
+    });
+
+    it('shows Amoy on 127.0.0.1', async () => {
+        const networks = await loadNetworksModule({
+            hostname: '127.0.0.1'
+        });
+
+        expect(networks.getAllNetworks().map((network) => network.slug)).toContain('amoy');
+        expect(networks.getNetworkBySlug('amoy')?.slug).toBe('amoy');
+    });
+
+    it('shows and selects Amoy when explicitly requested in the URL', async () => {
+        const networks = await loadNetworksModule({
+            hostname: 'whaleswap.finance',
+            search: '?chain=amoy'
+        });
+
+        expect(networks.getRequestedNetworkSlugFromUrl()).toBe('amoy');
+        expect(networks.getAllNetworks().map((network) => network.slug)).toContain('amoy');
+        expect(networks.getNetworkBySlug('amoy')?.slug).toBe('amoy');
+    });
+});


### PR DESCRIPTION
## Summary
- hide Polygon Amoy by default on production hosts
- keep Amoy available on localhost and when explicitly requested via ?chain=amoy
- add regression coverage for localhost, 127.0.0.1, and explicit Amoy selection

## Testing
- npx vitest run tests/networks.visibility.test.js tests/app.orderTabVisibility.test.js