### PR TITLE
Fix iPhone orders tab scroll jumping back up

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -46,7 +46,6 @@ class App {
 		this.tabRailScrollHandler = null;
 		this.tabRailLeftArrowHandler = null;
 		this.tabRailRightArrowHandler = null;
-		this.tabRailViewportWidth = null;
 		this.initialOrderSyncPromise = null;
 		this.tabReady = new Set();
 		this.activeTabRequestId = 0;
@@ -425,19 +424,12 @@ class App {
 			});
 	}
 
-	getViewportWidth() {
-		const viewportWidth = Number(window.visualViewport?.width);
-		return Number.isFinite(viewportWidth) ? viewportWidth : window.innerWidth;
-	}
-
 	initializeTabRail() {
 		this.tabRail = document.querySelector('[data-mobile-tab-rail="true"]');
 		this.tabRailShell = document.querySelector('[data-tab-rail-shell]');
 		this.tabRailLeftArrow = document.querySelector('[data-tab-rail-arrow="left"]');
 		this.tabRailRightArrow = document.querySelector('[data-tab-rail-arrow="right"]');
 		if (!this.tabRail) return;
-
-		this.tabRailViewportWidth = this.getViewportWidth();
 
 		if (!this.tabRailScrollHandler) {
 			this.tabRailScrollHandler = () => this.updateTabRailOverflowState();
@@ -455,22 +447,7 @@ class App {
 		}
 
 		if (!this.tabRailResizeHandler) {
-			this.tabRailResizeHandler = () => {
-				const nextViewportWidth = this.getViewportWidth();
-				const widthChanged = this.tabRailViewportWidth === null
-					|| Math.abs(nextViewportWidth - this.tabRailViewportWidth) > 1;
-
-				this.tabRailViewportWidth = nextViewportWidth;
-
-				// iOS Safari fires resize events while browser chrome expands/collapses during scroll.
-				// Ignore height-only viewport changes so vertical scrolling cannot yank the page to the tab rail.
-				if (!widthChanged) {
-					this.updateTabRailOverflowState();
-					return;
-				}
-
-				this.scrollActiveTabIntoView({ behavior: 'auto' });
-			};
+			this.tabRailResizeHandler = () => this.updateTabRailOverflowState();
 			window.addEventListener('resize', this.tabRailResizeHandler);
 		}
 
@@ -509,65 +486,6 @@ class App {
 		if (this.tabRailRightArrow) {
 			this.tabRailRightArrow.disabled = !(shouldShowArrows && canScrollRight);
 		}
-	}
-
-	getVisibleActiveTabButton() {
-		if (!this.tabRail) return null;
-		const candidates = Array.from(this.tabRail.querySelectorAll('.tab-button.active'));
-		for (const button of candidates) {
-			const style = window.getComputedStyle(button);
-			if (style.display !== 'none' && style.visibility !== 'hidden') {
-				return button;
-			}
-		}
-		return null;
-	}
-
-	scrollActiveTabIntoView({ behavior = 'smooth' } = {}) {
-		if (!this.tabRail) {
-			this.initializeTabRail();
-		}
-		if (!window.matchMedia('(max-width: 768px)').matches) {
-			this.updateTabRailOverflowState();
-			return;
-		}
-
-		const activeButton = this.getVisibleActiveTabButton();
-		if (!activeButton) {
-			this.updateTabRailOverflowState();
-			return;
-		}
-
-		const railWidth = this.tabRail.clientWidth;
-		const maxScrollLeft = Math.max(this.tabRail.scrollWidth - railWidth, 0);
-		if (railWidth <= 0 || maxScrollLeft <= 0) {
-			this.updateTabRailOverflowState();
-			return;
-		}
-
-		const railRect = this.tabRail.getBoundingClientRect();
-		const activeButtonRect = activeButton.getBoundingClientRect();
-		const currentScrollLeft = this.tabRail.scrollLeft;
-		const buttonCenter = currentScrollLeft
-			+ (activeButtonRect.left - railRect.left)
-			+ (activeButtonRect.width / 2);
-		const targetScrollLeft = Math.min(
-			Math.max(buttonCenter - (railWidth / 2), 0),
-			maxScrollLeft
-		);
-
-		if (Math.abs(targetScrollLeft - currentScrollLeft) > 1) {
-			if (typeof this.tabRail.scrollTo === 'function') {
-				this.tabRail.scrollTo({
-					left: targetScrollLeft,
-					behavior
-				});
-			} else {
-				this.tabRail.scrollLeft = targetScrollLeft;
-			}
-		}
-
-		window.setTimeout(() => this.updateTabRailOverflowState(), 140);
 	}
 
 	getTabSkeletonVariant(tabId) {
@@ -1216,8 +1134,6 @@ class App {
 					}
 				}
 
-				this.scrollActiveTabIntoView({ behavior: 'auto' });
-
 				this.scheduleOrderTabVisibilityRefresh();
 				this.scheduleClaimTabVisibilityRefresh();
 			};
@@ -1585,7 +1501,6 @@ class App {
 				}
 			});
 			this.currentTab = tabId;
-			this.scrollActiveTabIntoView();
 
 			// Show and initialize selected tab
 			if (tabContent) {


### PR DESCRIPTION
## Summary
This stops the mobile orders pages from jumping back up while scrolling on iPhone by removing the automatic tab-bar repositioning.

## Problem
On mobile, the top tab bar can scroll sideways because there are more tabs than fit on screen.

We also had extra code that tried to help by automatically moving the selected tab button into view. That meant while the user was scrolling the page, the app could also tell the browser to reposition the tab bar.

On iPhone Safari, that was risky. Instead of only moving the horizontal tab bar, Safari could also move the whole page vertically. The result was the bug users saw: while reading a long orders list, the page could suddenly jump back up toward the navigation tabs.

## Fix
The fix is intentionally simple:

- keep the tab bar manually scrollable
- keep the left/right overflow arrows
- remove all automatic "scroll the active tab into view" behavior

## Why This Works
The tab bar still works the same way for the user: if there are too many tabs, they can swipe it or use the arrows.

What is gone is the automatic browser call that could unexpectedly reposition the page during normal scrolling. With that behavior removed, scrolling through long order lists no longer fights with the tab bar.

## Testing
- `npm test`