### PR TITLE
Restrict create order amount inputs

### DIFF
--- a/js/components/CreateOrder.js
+++ b/js/components/CreateOrder.js
@@ -2667,20 +2667,22 @@ export class CreateOrder extends BaseComponent {
         try {
             const amount = document.getElementById(`${type}Amount`)?.value || '0';
             const token = this[`${type}Token`];
+            const numericAmount = Number(amount);
             
             // Find USD display element
             let usdDisplay = document.getElementById(`${type}AmountUSD`);
             
             // If no token selected or amount is 0/empty, hide the USD display without removing
-            if (!token || !amount || amount === '0') {
+            if (!token || !amount || !Number.isFinite(numericAmount) || numericAmount <= 0) {
                 if (usdDisplay) {
                     setVisibility(usdDisplay, false);
                 }
+                this.updateCreateButtonState();
                 return;
             }
             
             if (token && amount) {
-                const usdValue = token.usdPrice !== undefined ? Number(amount) * token.usdPrice : 0;
+                const usdValue = token.usdPrice !== undefined ? numericAmount * token.usdPrice : 0;
                 // Ensure USD display element exists (in template) and update it
                 if (!usdDisplay) {
                     usdDisplay = document.getElementById(`${type}AmountUSD`);

--- a/tests/createOrder.amountInput.test.js
+++ b/tests/createOrder.amountInput.test.js
@@ -104,4 +104,30 @@ describe('CreateOrder amount input sanitizing', () => {
 
         expect(buyAmountInput.value).toBe('987');
     });
+
+    it('hides the USD preview for a lone decimal input', () => {
+        document.body.innerHTML = `
+            <div id="create-order"></div>
+            <input id="sellAmount" type="text" />
+            <div id="sellAmountUSD" class="amount-usd"></div>
+        `;
+
+        const component = new CreateOrder();
+        component.setContext(createContextStub());
+        component.sellToken = { decimals: 18, usdPrice: 2 };
+
+        const updateCreateButtonStateSpy = vi.spyOn(component, 'updateCreateButtonState').mockImplementation(() => {});
+
+        component.initializeAmountInputs();
+
+        const sellAmountInput = document.getElementById('sellAmount');
+        const sellAmountUsd = document.getElementById('sellAmountUSD');
+        sellAmountInput.value = '.';
+        sellAmountInput.dispatchEvent(new Event('input', { bubbles: true }));
+
+        expect(sellAmountUsd.textContent).not.toContain('NaN');
+        expect(sellAmountUsd.classList.contains('is-hidden')).toBe(true);
+        expect(sellAmountUsd.getAttribute('aria-hidden')).toBe('true');
+        expect(updateCreateButtonStateSpy).toHaveBeenCalled();
+    });
 });


### PR DESCRIPTION
## Summary
- Restrict create-order amount fields to numeric input with a single decimal point.
- Respect the selected token's decimals by truncating excess fractional precision.
- Add focused CreateOrder tests for sanitizing and token-decimals behavior.

## Testing
- `npm test -- createOrder.amountInput.test.js createOrder.displaySymbol.test.js createOrder.modalOutsideClick.test.js`