### PR TITLE
Rescan wallet assets when opening Create Order selectors

### DIFF
--- a/js/components/CreateOrder.js
+++ b/js/components/CreateOrder.js
@@ -493,7 +493,6 @@ export class CreateOrder extends BaseComponent {
         }
         if (this.initialized) {
             this.debug('Already initialized, refreshing active state only');
-            this.isReadOnlyMode = Boolean(readOnlyMode);
             if (readOnlyMode) {
                 this.setReadOnlyMode();
             } else {
@@ -648,6 +647,12 @@ export class CreateOrder extends BaseComponent {
         this.tokensLoading = true;
         this.setAllowedTokenListsLoadingState('Loading allowed tokens...');
         this.allowedTokensLoadPromise = this.loadContractTokens()
+            .then((tokens) => {
+                if (forceFresh && !this.isReadOnlyMode) {
+                    void this.requestVisibleBalanceRefresh(`${source}:post-force-refresh`);
+                }
+                return tokens;
+            })
             .catch((error) => {
                 this.debug(`Allowed token refresh failed (${source}):`, error);
             })
@@ -1897,13 +1902,6 @@ export class CreateOrder extends BaseComponent {
             // Clear the container and add the new structure
             currentContainer.innerHTML = '';
             currentContainer.appendChild(container);
-            
-            // Add event listeners
-            tokenSelector.addEventListener('click', () => {
-                const modal = document.getElementById(`${type}TokenModal`);
-                if (modal) modal.classList.add('show');
-            });
-            
             // Create modal if it doesn't exist
             if (!document.getElementById(`${type}TokenModal`)) {
                 const modal = this.createTokenModal(type);

--- a/tests/createOrder.lazyBalanceRefresh.test.js
+++ b/tests/createOrder.lazyBalanceRefresh.test.js
@@ -2,12 +2,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockGetAllWalletTokens = vi.fn();
 const mockGetContractAllowedTokens = vi.fn();
-const mockClearTokenCaches = vi.fn();
 
 vi.mock('../js/utils/contractTokens.js', () => ({
     getAllWalletTokens: (...args) => mockGetAllWalletTokens(...args),
     getContractAllowedTokens: (...args) => mockGetContractAllowedTokens(...args),
-    clearTokenCaches: (...args) => mockClearTokenCaches(...args),
+    clearTokenCaches: vi.fn(),
 }));
 
 import { CreateOrder } from '../js/components/CreateOrder.js';
@@ -68,7 +67,6 @@ beforeEach(() => {
     vi.restoreAllMocks();
     mockGetAllWalletTokens.mockReset();
     mockGetContractAllowedTokens.mockReset();
-    mockClearTokenCaches.mockReset();
 });
 
 afterEach(() => {
@@ -152,6 +150,36 @@ describe('CreateOrder lazy balance refresh', () => {
 
         expect(document.getElementById('sellTokenModal')?.style.display).toBe('block');
         expect(refreshSpy).toHaveBeenCalledWith('sell-selector-open');
+    });
+
+    it('refreshes balances after a forced allowed-token reload in connected mode', async () => {
+        setupTokenModalDom();
+        mockGetContractAllowedTokens.mockResolvedValue([
+            {
+                address: TOKEN_A,
+                symbol: 'AAA',
+                name: 'Alpha',
+                decimals: 18,
+                balance: null,
+                balanceLoading: true,
+                iconUrl: 'fallback',
+            },
+        ]);
+
+        const component = new CreateOrder();
+        component.setContext(createContextStub());
+        component.isReadOnlyMode = false;
+
+        const refreshSpy = vi
+            .spyOn(component, 'requestVisibleBalanceRefresh')
+            .mockResolvedValue([]);
+
+        await component.requestAllowedTokensRefresh({
+            forceFresh: true,
+            source: 'AllowedTokensUpdated',
+        });
+
+        expect(refreshSpy).toHaveBeenCalledWith('AllowedTokensUpdated:post-force-refresh');
     });
 
     it('renders disconnected token rows without loading placeholders', () => {


### PR DESCRIPTION
## Summary
- refactor Create Order token loading so the allowed token list and metadata still load into local in-memory component state, but wallet balances are no longer eagerly rescanned during initialization
- add a single `requestVisibleBalanceRefresh()` entry point to keep the balance-refresh logic DRY and reuse the existing batch balance path when Create Order becomes active or when the user opens the Buy or Sell token selector
- preserve the original issue intent of rescanning wallet assets closer to user interaction instead of relying on the initial connected-state snapshot
- fix follow-on local UI state regressions from lazy loading by rendering disconnected/read-only token rows without permanent loading placeholders and by scheduling one balance refresh after a forced allowed-token reload in connected mode
- add focused regression coverage for the lazy refresh flow, selector-open behavior, connected tab re-entry, read-only rendering, and forced allowed-token reload handling

## Testing
- npx vitest run tests/createOrder.lazyBalanceRefresh.test.js tests/createOrder.displaySymbol.test.js tests/createOrder.modalOutsideClick.test.js tests/allowedTokensUpdated.behavior.test.js

Closes #111