### PR TITLE
Validate taker input on create order form

### DIFF
--- a/js/components/CreateOrder.js
+++ b/js/components/CreateOrder.js
@@ -20,6 +20,7 @@ import { buildTokenDisplaySymbolMap, getDisplaySymbol } from '../utils/tokenDisp
 
 const CREATE_ORDER_RELOAD_STATE_KEY = 'whaleswap:create-order:reload-state:v1';
 const CREATE_ORDER_RELOAD_STATE_MAX_AGE_MS = 5 * 60 * 1000;
+const TAKER_ADDRESS_MAX_LENGTH = 42;
 
 export class CreateOrder extends BaseComponent {
     constructor() {
@@ -155,7 +156,9 @@ export class CreateOrder extends BaseComponent {
     getCreateOrderFormStateForReload() {
         const sellAmount = document.getElementById('sellAmount')?.value?.trim() || '';
         const buyAmount = document.getElementById('buyAmount')?.value?.trim() || '';
-        const takerAddress = document.getElementById('takerAddress')?.value?.trim() || '';
+        const takerAddress = this.sanitizeTakerAddressInput(
+            document.getElementById('takerAddress')?.value?.trim() || ''
+        );
         const takerToggle = this.container?.querySelector('.taker-toggle');
         const isTakerExpanded = Boolean(takerToggle?.classList.contains('active'));
         const selectedChainSlug = this.ctx?.getSelectedChainSlug?.() || getNetworkConfig()?.slug || null;
@@ -260,6 +263,35 @@ export class CreateOrder extends BaseComponent {
         }
     }
 
+    sanitizeTakerAddressInput(value) {
+        const normalizedValue = String(value ?? '').trim().toLowerCase();
+        if (!normalizedValue) {
+            return '';
+        }
+
+        if (normalizedValue.startsWith('0x')) {
+            return `0x${normalizedValue.slice(2).replace(/[^0-9a-f]/g, '')}`.slice(0, TAKER_ADDRESS_MAX_LENGTH);
+        }
+
+        if (normalizedValue.startsWith('0')) {
+            return `0${normalizedValue.slice(1).replace(/[^0-9a-f]/g, '')}`.slice(0, TAKER_ADDRESS_MAX_LENGTH);
+        }
+
+        return normalizedValue.replace(/[^0-9a-f]/g, '').slice(0, TAKER_ADDRESS_MAX_LENGTH);
+    }
+
+    initializeTakerAddressInput() {
+        const takerAddressInput = document.getElementById('takerAddress');
+        if (!takerAddressInput) {
+            return;
+        }
+
+        takerAddressInput.oninput = () => {
+            takerAddressInput.value = this.sanitizeTakerAddressInput(takerAddressInput.value);
+        };
+        takerAddressInput.value = this.sanitizeTakerAddressInput(takerAddressInput.value);
+    }
+
     async applyReloadFormState(snapshot) {
         if (!snapshot) {
             return { clearSnapshot: false, restored: false };
@@ -310,7 +342,7 @@ export class CreateOrder extends BaseComponent {
         this.setTakerExpanded(Boolean(snapshot.isTakerExpanded));
         const takerAddressInput = document.getElementById('takerAddress');
         if (takerAddressInput) {
-            takerAddressInput.value = snapshot.takerAddress || '';
+            takerAddressInput.value = this.sanitizeTakerAddressInput(snapshot.takerAddress || '');
         }
 
         const restoredSellToken = !snapshot.sellTokenAddress
@@ -491,6 +523,7 @@ export class CreateOrder extends BaseComponent {
             
             // Initialize amount input listeners
             this.initializeAmountInputs();
+            this.initializeTakerAddressInput();
 
             await this.restorePendingReloadFormState();
             
@@ -1244,7 +1277,11 @@ export class CreateOrder extends BaseComponent {
             this.debug('Current buyToken:', this.buyToken);
             
             // Get form values
-            let taker = document.getElementById('takerAddress')?.value.trim() || '';
+            const takerAddressInput = document.getElementById('takerAddress');
+            let taker = this.sanitizeTakerAddressInput(takerAddressInput?.value?.trim() || '');
+            if (takerAddressInput && takerAddressInput.value !== taker) {
+                takerAddressInput.value = taker;
+            }
             
             // Validate sell token
             if (!this.sellToken || !this.sellToken.address) {
@@ -2893,7 +2930,16 @@ export class CreateOrder extends BaseComponent {
                             </span>
                         </div>
                         <div id="taker-input-content" class="taker-input-content hidden">
-                            <input type="text" id="takerAddress" class="taker-address-input" placeholder="0x..." />
+                            <input
+                                type="text"
+                                id="takerAddress"
+                                class="taker-address-input"
+                                placeholder="0x..."
+                                maxlength="${TAKER_ADDRESS_MAX_LENGTH}"
+                                autocomplete="off"
+                                autocapitalize="off"
+                                spellcheck="false"
+                            />
                         </div>
                     </div>
 

--- a/tests/createOrder.takerInput.test.js
+++ b/tests/createOrder.takerInput.test.js
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { CreateOrder } from '../js/components/CreateOrder.js';
+
+function setupCreateOrderDom() {
+    document.body.innerHTML = '<div id="create-order"></div>';
+}
+
+function createContextStub() {
+    return {
+        getSelectedChainSlug: () => 'test-chain',
+        showError: () => {},
+        showSuccess: () => {},
+        showWarning: () => {},
+        showInfo: () => {},
+    };
+}
+
+afterEach(() => {
+    document.body.innerHTML = '';
+});
+
+describe('CreateOrder taker address input', () => {
+    it('sanitizes live taker input to 0x plus hex characters', () => {
+        setupCreateOrderDom();
+
+        const component = new CreateOrder();
+        component.container.innerHTML = component.render();
+        component.initializeTakerAddressInput();
+
+        const takerAddressInput = document.getElementById('takerAddress');
+        takerAddressInput.value = '0X12g-34 yz';
+        takerAddressInput.dispatchEvent(new Event('input', { bubbles: true }));
+
+        expect(takerAddressInput.value).toBe('0x1234');
+    });
+
+    it('limits taker input to a 42-character address length', () => {
+        setupCreateOrderDom();
+
+        const component = new CreateOrder();
+        component.container.innerHTML = component.render();
+        component.initializeTakerAddressInput();
+
+        const takerAddressInput = document.getElementById('takerAddress');
+        takerAddressInput.value = `0x${'a'.repeat(50)}`;
+        takerAddressInput.dispatchEvent(new Event('input', { bubbles: true }));
+
+        expect(takerAddressInput.maxLength).toBe(42);
+        expect(takerAddressInput.value).toBe(`0x${'a'.repeat(40)}`);
+    });
+
+    it('sanitizes restored taker input from saved form state', async () => {
+        setupCreateOrderDom();
+
+        const component = new CreateOrder();
+        component.setContext(createContextStub());
+        component.container.innerHTML = component.render();
+        component.tokens = [{}];
+        component.initializeTakerAddressInput();
+
+        await component.applyReloadFormState({
+            selectedChainSlug: 'test-chain',
+            takerAddress: '0X12g3456---7890',
+            isTakerExpanded: true,
+        });
+
+        expect(document.getElementById('takerAddress').value).toBe('0x1234567890');
+    });
+});

--- a/tests/createOrder.takerSubmit.test.js
+++ b/tests/createOrder.takerSubmit.test.js
@@ -1,0 +1,172 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const { mockEthersContract, mockValidateSellBalance } = vi.hoisted(() => ({
+    mockEthersContract: vi.fn(),
+    mockValidateSellBalance: vi.fn(),
+}));
+
+vi.mock('ethers', async () => {
+    const actual = await vi.importActual('ethers');
+    return {
+        ...actual,
+        ethers: {
+            ...actual.ethers,
+            Contract: mockEthersContract,
+        },
+    };
+});
+
+vi.mock('../js/utils/balanceValidation.js', async () => {
+    const actual = await vi.importActual('../js/utils/balanceValidation.js');
+    return {
+        ...actual,
+        validateSellBalance: mockValidateSellBalance,
+    };
+});
+
+import { CreateOrder } from '../js/components/CreateOrder.js';
+import { contractService } from '../js/services/ContractService.js';
+import { walletManager } from '../js/services/WalletManager.js';
+
+const ACCOUNT = '0x3333333333333333333333333333333333333333';
+const SELL_TOKEN = '0x1111111111111111111111111111111111111111';
+const BUY_TOKEN = '0x2222222222222222222222222222222222222222';
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+const TX_HASH = `0x${'a'.repeat(64)}`;
+
+function setupCreateOrderDom() {
+    document.body.innerHTML = '<div id="create-order"></div>';
+}
+
+function createToastStub() {
+    return {
+        createTransactionProgress: vi.fn(() => ({
+            onClose: vi.fn(),
+            updateStep: vi.fn(),
+            setSummary: vi.fn(),
+            setTransaction: vi.fn(),
+            finishSuccess: vi.fn(),
+            finishFailure: vi.fn(),
+            finishCancelled: vi.fn(),
+        })),
+    };
+}
+
+function createSubmitHarness({ takerValue = '' } = {}) {
+    setupCreateOrderDom();
+
+    const toast = createToastStub();
+    const ws = {
+        syncAllOrders: vi.fn(async () => {}),
+    };
+    const ctx = {
+        toast,
+        getWebSocket: () => ws,
+        getWalletChainId: () => '0x89',
+        getSelectedChainSlug: () => 'test-chain',
+        showError: vi.fn(),
+        showSuccess: vi.fn(),
+        showWarning: vi.fn(),
+        showInfo: vi.fn(),
+    };
+
+    const component = new CreateOrder();
+    component.setContext(ctx);
+    component.container.innerHTML = component.render();
+    component.sellToken = {
+        address: SELL_TOKEN,
+        symbol: 'SELL',
+        displaySymbol: 'SELL',
+        decimals: 18,
+    };
+    component.buyToken = {
+        address: BUY_TOKEN,
+        symbol: 'BUY',
+        displaySymbol: 'BUY',
+        decimals: 18,
+    };
+
+    document.getElementById('sellAmount').value = '1';
+    document.getElementById('buyAmount').value = '2';
+    document.getElementById('takerAddress').value = takerValue;
+
+    component.refreshContractDisabledState = vi.fn(async () => false);
+    component.ensureWalletReadyForWrite = vi.fn(async () => true);
+    component.getTokenDecimals = vi.fn(async () => 18);
+    component.getCreateOrderApprovalRequirements = vi.fn(async () => []);
+    component.updateCreateButtonState = vi.fn();
+    component.refreshOpenTokenModals = vi.fn();
+    component.debug = vi.fn();
+    component.error = vi.fn();
+    component.showError = vi.fn();
+    component.showWarning = vi.fn();
+
+    mockValidateSellBalance.mockResolvedValue({
+        hasSufficientBalance: true,
+        symbol: 'SELL',
+        formattedRequired: '1',
+        formattedBalance: '10',
+    });
+
+    const signer = {
+        getAddress: vi.fn(async () => ACCOUNT),
+    };
+    vi.spyOn(walletManager, 'getSigner').mockReturnValue(signer);
+    vi.spyOn(contractService, 'isTokenAllowed').mockResolvedValue(true);
+
+    const tx = {
+        hash: TX_HASH,
+        wait: vi.fn(async () => ({ status: 1 })),
+    };
+    const contract = {
+        createOrder: vi.fn(async () => tx),
+    };
+    mockEthersContract.mockImplementation(() => contract);
+
+    return { component, contract };
+}
+
+afterEach(() => {
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+    mockEthersContract.mockReset();
+    mockValidateSellBalance.mockReset();
+});
+
+describe('CreateOrder taker submit handling', () => {
+    it('accepts a bare 40-hex taker address without 0x on submit', async () => {
+        const bareAddress = 'abcdefabcdefabcdefabcdefabcdefabcdefabcd';
+        const { component, contract } = createSubmitHarness({
+            takerValue: bareAddress,
+        });
+
+        await component.handleCreateOrder({ preventDefault: vi.fn() });
+
+        expect(contract.createOrder).toHaveBeenCalledTimes(1);
+        expect(contract.createOrder.mock.calls[0][0]).toBe(bareAddress);
+        expect(component.showError).not.toHaveBeenCalled();
+    });
+
+    it('maps an empty taker field to the zero address on submit', async () => {
+        const { component, contract } = createSubmitHarness({
+            takerValue: '',
+        });
+
+        await component.handleCreateOrder({ preventDefault: vi.fn() });
+
+        expect(contract.createOrder).toHaveBeenCalledTimes(1);
+        expect(contract.createOrder.mock.calls[0][0]).toBe(ZERO_ADDRESS);
+        expect(component.showError).not.toHaveBeenCalled();
+    });
+
+    it('rejects malformed taker hex on submit', async () => {
+        const { component, contract } = createSubmitHarness({
+            takerValue: '0x1234',
+        });
+
+        await component.handleCreateOrder({ preventDefault: vi.fn() });
+
+        expect(contract.createOrder).not.toHaveBeenCalled();
+        expect(component.showError).toHaveBeenCalledWith('Invalid taker address format');
+    });
+});


### PR DESCRIPTION
## Summary
- sanitize the create-order taker field to hex-only input with a 42-character limit
- normalize restored and submit-time taker values before the existing address validation runs
- add focused UI tests for live input behavior and submit-path taker handling

## Testing
- npm test -- tests/createOrder.takerInput.test.js tests/createOrder.takerSubmit.test.js tests/createOrder.modalOutsideClick.test.js tests/createOrder.displaySymbol.test.js

Fixes #115
