### PR TITLE
Show <$0.01 for sub-cent create-order USD preview

### DIFF
--- a/js/components/CreateOrder.js
+++ b/js/components/CreateOrder.js
@@ -2796,7 +2796,9 @@ export class CreateOrder extends BaseComponent {
                     usdDisplay = document.getElementById(`${type}AmountUSD`);
                 }
                 if (usdDisplay) {
-                    usdDisplay.textContent = token.usdPrice !== undefined ? `$${usdValue.toFixed(2)}` : 'N/A';
+                    usdDisplay.textContent = token.usdPrice === undefined
+                        ? 'N/A'
+                        : (usdValue > 0 && usdValue < 0.01 ? '<$0.01' : `$${usdValue.toFixed(2)}`);
                     setVisibility(usdDisplay, true);
                 }
             }

--- a/tests/createOrder.amountInput.test.js
+++ b/tests/createOrder.amountInput.test.js
@@ -130,4 +130,27 @@ describe('CreateOrder amount input sanitizing', () => {
         expect(sellAmountUsd.getAttribute('aria-hidden')).toBe('true');
         expect(updateCreateButtonStateSpy).toHaveBeenCalled();
     });
+
+    it('shows a sub-cent USD preview without rounding down to zero', () => {
+        document.body.innerHTML = `
+            <div id="create-order"></div>
+            <input id="sellAmount" type="text" />
+            <div id="sellAmountUSD" class="amount-usd is-hidden" aria-hidden="true"></div>
+        `;
+
+        const component = new CreateOrder();
+        component.setContext(createContextStub());
+        component.sellToken = { decimals: 18, usdPrice: 0.005 };
+
+        component.initializeAmountInputs();
+
+        const sellAmountInput = document.getElementById('sellAmount');
+        const sellAmountUsd = document.getElementById('sellAmountUSD');
+        sellAmountInput.value = '1';
+        sellAmountInput.dispatchEvent(new Event('input', { bubbles: true }));
+
+        expect(sellAmountUsd.textContent).toBe('<$0.01');
+        expect(sellAmountUsd.classList.contains('is-hidden')).toBe(false);
+        expect(sellAmountUsd.getAttribute('aria-hidden')).toBe('false');
+    });
 });


### PR DESCRIPTION
## Summary
- Show `<$0.01` in the Create Orders USD preview when the computed value is non-zero but below one cent.
- Keep the existing 2-decimal display for values at or above one cent.
- Add a focused regression test for the sub-cent preview case.

## Testing
- `npx vitest run tests/createOrder.amountInput.test.js`

## Issue
- Refs #120

<img width="387" height="462" alt="image" src="https://github.com/user-attachments/assets/4c4ac9a9-cd60-422b-9fa3-5b83eb78a2d9" />

