### PR TITLE
Use footer legal links on desktop

### DIFF
--- a/css/components/footer.css
+++ b/css/components/footer.css
@@ -3,10 +3,10 @@
   border-top: 1px solid var(--border-color, #e0e0e0);
   background: transparent;
   display: flex;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
   gap: 12px;
-  flex-wrap: wrap;
 }
 
 .footer-wrapper {
@@ -36,10 +36,11 @@
 }
 
 .legal-help-inline {
-  display: none;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: 8px;
+  flex-wrap: wrap;
 }
 
 .legal-help-inline-item {
@@ -60,74 +61,6 @@
 
 [data-theme="dark"] .legal-help-inline-item {
   background: rgba(148, 163, 184, 0.16);
-}
-
-.legal-help-launcher {
-  position: fixed;
-  right: 24px;
-  bottom: 24px;
-  width: 32px;
-  height: 32px;
-  border-radius: 999px;
-  border: 1px solid var(--border-color, #e0e0e0);
-  background: var(--bg-secondary, #ffffff);
-  color: var(--text-primary);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 16px;
-  cursor: pointer;
-  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.18);
-  z-index: 60;
-}
-
-.legal-help-launcher:hover {
-  background: var(--bg-hover, #f5f5f5);
-}
-
-[data-theme="dark"] .legal-help-launcher {
-  background: var(--bg-secondary, #1f2933);
-}
-
-.legal-help-dropdown {
-  position: fixed;
-  right: 24px;
-  bottom: 64px;
-  min-width: 220px;
-  background: var(--bg-secondary, #ffffff);
-  border-radius: 16px;
-  border: 1px solid var(--border-color, #e0e0e0);
-  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.24);
-  padding: 10px 0;
-  z-index: 60;
-}
-
-.legal-help-dropdown[hidden] {
-  display: none !important;
-}
-
-.legal-help-header {
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--text-secondary);
-  padding: 4px 16px 8px 16px;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-}
-
-.legal-help-item {
-  width: 100%;
-  border: none;
-  background: transparent;
-  padding: 8px 16px;
-  text-align: left;
-  font-size: 14px;
-  color: var(--text-primary);
-  cursor: pointer;
-}
-
-.legal-help-item:hover {
-  background: var(--bg-hover, #f5f5f5);
 }
 
 .legal-modal-overlay {
@@ -374,14 +307,7 @@
   }
 
   .legal-help-inline {
-    display: inline-flex;
     width: 100%;
-    flex-wrap: wrap;
-  }
-
-  .legal-help-launcher,
-  .legal-help-dropdown {
-    display: none !important;
   }
 
   .legal-modal {

--- a/js/components/Footer.js
+++ b/js/components/Footer.js
@@ -37,31 +37,6 @@ export class Footer extends BaseComponent {
                     Privacy
                 </button>
             </div>
-            <button
-                type="button"
-                class="legal-help-launcher"
-                id="legal-help-launcher"
-                aria-label="Legal information"
-            >
-                ?
-            </button>
-            <div class="legal-help-dropdown" id="legal-help-dropdown" hidden>
-                <div class="legal-help-header">Links</div>
-                <button
-                    type="button"
-                    class="legal-help-item"
-                    data-legal-target="tos"
-                >
-                    Terms of Service
-                </button>
-                <button
-                    type="button"
-                    class="legal-help-item"
-                    data-legal-target="privacy"
-                >
-                    Privacy Policy
-                </button>
-            </div>
             <div class="legal-modal-overlay" id="legal-modal-overlay" hidden>
                 <div class="legal-modal" role="dialog" aria-modal="true" aria-labelledby="legal-modal-title">
                     <div class="legal-modal-header">
@@ -84,15 +59,13 @@ export class Footer extends BaseComponent {
     }
 
     bindEvents() {
-        const launcher = document.getElementById('legal-help-launcher');
-        const dropdown = document.getElementById('legal-help-dropdown');
         const inlineActions = document.getElementById('legal-help-inline');
         const overlay = document.getElementById('legal-modal-overlay');
         const closeButton = document.getElementById('legal-modal-close');
         const modalTitle = document.getElementById('legal-modal-title');
         const modalBody = document.getElementById('legal-modal-body');
 
-        if (!launcher || !dropdown || !overlay || !closeButton || !modalTitle || !modalBody) {
+        if (!inlineActions || !overlay || !closeButton || !modalTitle || !modalBody) {
             return;
         }
 
@@ -170,21 +143,6 @@ export class Footer extends BaseComponent {
             }
         };
 
-        const toggleDropdown = () => {
-            const isHidden = dropdown.hasAttribute('hidden');
-            if (isHidden) {
-                dropdown.removeAttribute('hidden');
-            } else {
-                dropdown.setAttribute('hidden', '');
-            }
-        };
-
-        const closeDropdown = () => {
-            if (!dropdown.hasAttribute('hidden')) {
-                dropdown.setAttribute('hidden', '');
-            }
-        };
-
         const openModal = async (type) => {
             if (type === 'tos') {
                 modalTitle.textContent = 'Terms of Service';
@@ -204,7 +162,6 @@ export class Footer extends BaseComponent {
                 return;
             }
             overlay.removeAttribute('hidden');
-            closeDropdown();
         };
 
         const closeModal = () => {
@@ -213,20 +170,7 @@ export class Footer extends BaseComponent {
             }
         };
 
-        launcher.addEventListener('click', (event) => {
-            event.stopPropagation();
-            toggleDropdown();
-        });
-
-        dropdown.addEventListener('click', (event) => {
-            const target = event.target;
-            if (!(target instanceof HTMLElement)) return;
-            const type = target.getAttribute('data-legal-target');
-            if (!type) return;
-            openModal(type);
-        });
-
-        inlineActions?.addEventListener('click', (event) => {
+        inlineActions.addEventListener('click', (event) => {
             const target = event.target;
             if (!(target instanceof HTMLElement)) return;
             const type = target.getAttribute('data-legal-target');
@@ -241,14 +185,6 @@ export class Footer extends BaseComponent {
         overlay.addEventListener('click', (event) => {
             if (event.target === overlay) {
                 closeModal();
-            }
-        });
-
-        document.addEventListener('click', (event) => {
-            const target = event.target;
-            if (!(target instanceof HTMLElement)) return;
-            if (!dropdown.contains(target) && target !== launcher) {
-                closeDropdown();
             }
         });
     }


### PR DESCRIPTION
## Summary
- remove the desktop legal help launcher and dropdown from the footer
- show the Terms and Privacy footer links across all breakpoints
- stack the legal links beneath the Built by Liberdus section so desktop matches mobile

<img width="1218" height="627" alt="image" src="https://github.com/user-attachments/assets/17cf8807-eaff-457f-ad1e-6ac7e6e29509" />


