### PR TITLE
Harden claim tab refresh after cancel

### DIFF
--- a/js/components/MyOrders.js
+++ b/js/components/MyOrders.js
@@ -59,6 +59,20 @@ export class MyOrders extends BaseComponent {
         });
     }
 
+    scheduleClaimVisibilityRefreshAfterCancel() {
+        const app = window.app;
+        if (typeof app?.scheduleClaimTabVisibilityRefresh === 'function') {
+            app.scheduleClaimTabVisibilityRefresh(null, { force: true });
+            return;
+        }
+
+        if (typeof app?.refreshClaimTabVisibility === 'function') {
+            app.refreshClaimTabVisibility({ force: true }).catch((error) => {
+                this.debug('Fallback claim-tab visibility refresh failed:', error);
+            });
+        }
+    }
+
     async initialize(readOnlyMode = true) {
         // Prevent concurrent initializations
         if (this.isInitializing) {
@@ -391,6 +405,8 @@ export class MyOrders extends BaseComponent {
                             throw new Error('Transaction reverted by contract');
                         }
 
+                        this.scheduleClaimVisibilityRefreshAfterCancel();
+
                         // Show success notification
                         this.showSuccess(`Order ${order.id} cancelled successfully!`);
 
@@ -497,6 +513,8 @@ export class MyOrders extends BaseComponent {
                         if (receipt.status === 0) {
                             throw new Error('Transaction reverted by contract');
                         }
+
+                        this.scheduleClaimVisibilityRefreshAfterCancel();
 
                         this.showSuccess(`Order ${order.id} cancelled successfully! Go to the Claim tab to withdraw your tokens.`);
                         actionCell.textContent = '-';

--- a/tests/myOrders.cancelClaimVisibility.test.js
+++ b/tests/myOrders.cancelClaimVisibility.test.js
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ethers } from 'ethers';
+import { MyOrders } from '../js/components/MyOrders.js';
+
+const ACCOUNT = '0x1111111111111111111111111111111111111111';
+
+function createComponent() {
+    document.body.innerHTML = '<div id="my-orders"></div>';
+
+    const txWait = vi.fn(async () => ({ status: 1 }));
+    const contractWithSigner = {
+        estimateGas: {
+            cancelOrder: vi.fn(async () => ethers.BigNumber.from(100))
+        },
+        cancelOrder: vi.fn(async () => ({ wait: txWait }))
+    };
+
+    const ws = {
+        canCancelOrder: vi.fn(() => true),
+        contract: {
+            connect: vi.fn(() => contractWithSigner)
+        }
+    };
+
+    const component = new MyOrders();
+    component.setContext({
+        getWebSocket: () => ws,
+        getWallet: () => ({
+            getAccount: () => ACCOUNT
+        })
+    });
+    component.provider = {
+        getSigner: vi.fn(() => ({}))
+    };
+    component.ensureWalletReadyForWrite = vi.fn(async () => true);
+    component.showError = vi.fn();
+    component.showSuccess = vi.fn();
+    component.debouncedRefresh = vi.fn();
+
+    return { component, contractWithSigner, txWait };
+}
+
+async function flushAsyncWork() {
+    await Promise.resolve();
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+afterEach(() => {
+    document.body.innerHTML = '';
+    delete window.app;
+    vi.restoreAllMocks();
+});
+
+describe('MyOrders cancel claim-tab visibility hardening', () => {
+    it('schedules a claim-tab visibility refresh after a successful cancel', async () => {
+        const { component, contractWithSigner, txWait } = createComponent();
+        const actionCell = document.createElement('td');
+
+        window.app = {
+            scheduleClaimTabVisibilityRefresh: vi.fn()
+        };
+
+        component.updateActionColumn(actionCell, { id: 7, maker: ACCOUNT }, {
+            getAccount: () => ACCOUNT
+        });
+
+        const cancelButton = actionCell.querySelector('.cancel-order-btn');
+        expect(cancelButton).not.toBeNull();
+
+        cancelButton.click();
+        await flushAsyncWork();
+
+        expect(contractWithSigner.cancelOrder).toHaveBeenCalledTimes(1);
+        expect(txWait).toHaveBeenCalledTimes(1);
+        expect(window.app.scheduleClaimTabVisibilityRefresh).toHaveBeenCalledWith(null, { force: true });
+        expect(component.showSuccess).toHaveBeenCalledWith(
+            'Order 7 cancelled successfully! Go to the Claim tab to withdraw your tokens.'
+        );
+        expect(component.debouncedRefresh).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
## Summary
- harden the successful cancel flow so it explicitly refreshes claim-tab visibility after `tx.wait()`
- reuse the app's existing claim visibility refresh path instead of adding a separate claim read path
- add a focused Vitest regression test covering successful cancel -> claim-tab refresh scheduling

## Testing
- npm test
