### PR TITLE
Add outside-click dismissal for toasts

### DIFF
--- a/js/components/Toast.js
+++ b/js/components/Toast.js
@@ -2,6 +2,7 @@ import { createLogger } from '../services/LogService.js';
 import { getTransactionExplorerUrl } from '../utils/orderUtils.js';
 
 const TOAST_TYPES = ['error', 'success', 'warning', 'info'];
+const OUTSIDE_POINTER_LISTENER_OPTIONS = { capture: true };
 
 function shortenHash(hash) {
     if (!hash || hash.length < 12) return hash || '';
@@ -33,7 +34,7 @@ export class Toast {
 
     initialize() {
         this.createToastContainer();
-        document.addEventListener('pointerdown', this.boundDocumentPointerDownHandler);
+        document.addEventListener('pointerdown', this.boundDocumentPointerDownHandler, OUTSIDE_POINTER_LISTENER_OPTIONS);
         this.debug('Toast container ready');
     }
 
@@ -530,7 +531,7 @@ export class Toast {
     }
 
     destroy() {
-        document.removeEventListener('pointerdown', this.boundDocumentPointerDownHandler);
+        document.removeEventListener('pointerdown', this.boundDocumentPointerDownHandler, OUTSIDE_POINTER_LISTENER_OPTIONS);
 
         this.toastQueue = [];
         this.isProcessing = false;

--- a/tests/toast.test.js
+++ b/tests/toast.test.js
@@ -82,6 +82,23 @@ describe('Toast outside-click dismissal', () => {
         expect(document.querySelectorAll('.toast')).toHaveLength(0);
     });
 
+    it('dismisses toasts even when the outside target stops pointerdown propagation', () => {
+        const toast = createToast();
+        toast.showToast('Saved', 'success', 0, true);
+
+        const blocker = document.createElement('button');
+        blocker.type = 'button';
+        blocker.addEventListener('pointerdown', (event) => {
+            event.stopPropagation();
+        });
+        document.body.appendChild(blocker);
+
+        blocker.dispatchEvent(createPointerDownEvent());
+        advanceToastTimers(300);
+
+        expect(document.querySelectorAll('.toast')).toHaveLength(0);
+    });
+
     it('hides an active transaction progress toast and allows reopening it', () => {
         const toast = createToast();
         const session = createTransactionProgressSession(toast, {


### PR DESCRIPTION
## Summary
- add outside-click dismissal for mounted toasts in the toast component
- register the document-level pointer handler in capture phase so outside dismissal still works when other UI stops pointerdown propagation
- keep transaction progress toast behavior intact by routing dismissal through the existing close path
- add focused DOM tests for standard toasts, multi-toast dismissal, stopPropagation edge cases, and progress toast reopen behavior

## How It Works
- the toast component registers one document-level pointerdown handler in capture phase
- primary pointer interactions that start outside any visible toast dismiss all mounted toasts
- dismissal uses the existing removeToast path so timeout cleanup and _onClose callbacks still run
- active transaction progress toasts become hidden rather than lost, which preserves the current reopen flows used by create and fill sessions
- using capture phase ensures the toast manager still sees outside interactions before nested UI handlers can stop propagation

## Testing
- npm test -- tests/toast.test.js tests/createOrder.progressSession.test.js tests/ordersComponentHelper.fillProgress.test.js