### PR TITLE
Show spinner overlay during network switches

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -28,6 +28,7 @@
   --input-border: rgba(148, 163, 184, 0.38);
   --hover-bg: rgba(255, 255, 255, 0.78);
   --bg-hover: rgba(255, 255, 255, 0.78);
+  --loading-overlay-spinner-bg: rgba(255, 255, 255, 0.28);
 
   /* Card specific variables */
   --card-bg: rgba(255, 255, 255, 0.55);
@@ -88,6 +89,7 @@
   --input-border: rgba(148, 163, 184, 0.3);
   --hover-bg: rgba(53, 63, 82, 0.65);
   --bg-hover: rgba(53, 63, 82, 0.65);
+  --loading-overlay-spinner-bg: rgba(17, 24, 39, 0.3);
   --card-bg: rgba(20, 26, 37, 0.56);
   --card-shadow: 0 16px 36px rgba(0, 0, 0, 0.38);
   --card-border: 1px solid rgba(148, 163, 184, 0.18);
@@ -416,6 +418,28 @@ label {
   overflow: hidden;
 }
 
+.loading-overlay--global .loading-indicator--spinner {
+  display: none;
+}
+
+.loading-overlay--global.loading-overlay--spinner {
+  background: var(--loading-overlay-spinner-bg);
+  opacity: 1;
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  gap: 12px;
+}
+
+.loading-overlay--global.loading-overlay--spinner .loading-indicator--spinner {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.loading-overlay--global.loading-overlay--spinner .loading-skeleton {
+  display: none;
+}
+
 .loading-spinner {
   width: 40px;
   height: 40px;
@@ -687,6 +711,16 @@ label {
   z-index: 2;
   text-align: center;
   white-space: nowrap;
+}
+
+.loading-overlay--global.loading-overlay--spinner .loading-text {
+  position: static;
+  top: auto;
+  left: auto;
+  transform: none;
+  margin-top: 0;
+  max-width: min(320px, 88vw);
+  white-space: normal;
 }
 
 /* Remove any other loading/spinner styles that might exist */

--- a/index.html
+++ b/index.html
@@ -45,6 +45,33 @@
         }
       }
     </script>
+    <script>
+      (function () {
+        var BOOTSTRAP_LOADER_STATE_KEY = 'whaleswapBootstrapLoader';
+        var loaderState = null;
+
+        try {
+          var historyState = window.history && window.history.state ? window.history.state : {};
+          loaderState = historyState && historyState[BOOTSTRAP_LOADER_STATE_KEY]
+            ? historyState[BOOTSTRAP_LOADER_STATE_KEY]
+            : null;
+
+          if (loaderState && window.history && typeof window.history.replaceState === 'function') {
+            var nextHistoryState = Object.assign({}, historyState);
+            delete nextHistoryState[BOOTSTRAP_LOADER_STATE_KEY];
+            window.history.replaceState(nextHistoryState, '', window.location.href);
+          }
+        } catch (error) {
+          loaderState = null;
+        }
+
+        document.documentElement.dataset.bootstrapLoaderMode = loaderState && loaderState.mode === 'spinner'
+          ? 'spinner'
+          : 'skeleton';
+        window.__bootstrapLoaderState = loaderState;
+        window.__bootstrapLoaderTimeout = null;
+      })();
+    </script>
     <!-- Bootstrap loader styles (inline so loader appears immediately, even on slow networks) -->
     <style>
       #app-bootstrap-loader {
@@ -62,12 +89,44 @@
         text-align: center;
       }
 
+      #app-bootstrap-loader .loading-indicator--spinner {
+        display: none;
+        align-items: center;
+        justify-content: center;
+      }
+
+      #app-bootstrap-loader .loading-spinner {
+        width: 44px;
+        height: 44px;
+        border: 4px solid #d4dbea;
+        border-top-color: #4b6bfb;
+        border-radius: 50%;
+        animation: bootstrap-spin 1s linear infinite;
+      }
+
+      html[data-bootstrap-loader-mode='spinner'] #app-bootstrap-loader .loading-indicator--spinner,
+      #app-bootstrap-loader.loading-overlay--spinner .loading-indicator--spinner {
+        display: flex;
+      }
+
+      html[data-bootstrap-loader-mode='spinner'] #app-bootstrap-loader,
+      #app-bootstrap-loader.loading-overlay--spinner {
+        background: rgba(248, 249, 250, 0.28);
+        backdrop-filter: blur(4px);
+        -webkit-backdrop-filter: blur(4px);
+      }
+
       #app-bootstrap-loader .loading-skeleton--app {
         width: min(1320px, calc(100vw - 40px));
         display: flex;
         flex-direction: column;
         gap: 18px;
         margin-bottom: 12px;
+      }
+
+      html[data-bootstrap-loader-mode='spinner'] #app-bootstrap-loader .loading-skeleton--app,
+      #app-bootstrap-loader.loading-overlay--spinner .loading-skeleton--app {
+        display: none;
       }
 
       #app-bootstrap-loader .skeleton-block {
@@ -233,6 +292,17 @@
         z-index: 2;
       }
 
+      html[data-bootstrap-loader-mode='spinner'] #app-bootstrap-loader .loading-text,
+      #app-bootstrap-loader.loading-overlay--spinner .loading-text {
+        position: static;
+        top: auto;
+        left: auto;
+        transform: none;
+        margin-top: 12px;
+        max-width: min(320px, 88vw);
+        white-space: normal;
+      }
+
       #app-bootstrap-loader .loading-hint {
         position: absolute;
         top: calc(50% + 20px);
@@ -241,6 +311,17 @@
         font-size: 12px;
         color: #5c6474;
         width: min(540px, 92vw);
+      }
+
+      html[data-bootstrap-loader-mode='spinner'] #app-bootstrap-loader .loading-hint,
+      html[data-bootstrap-loader-mode='spinner'] #app-bootstrap-loader .loading-retry,
+      #app-bootstrap-loader.loading-overlay--spinner .loading-hint,
+      #app-bootstrap-loader.loading-overlay--spinner .loading-retry {
+        position: static;
+        top: auto;
+        left: auto;
+        transform: none;
+        margin-top: 12px;
       }
 
       #app-bootstrap-loader .loading-retry {
@@ -271,6 +352,15 @@
         }
         100% {
           background-position: -200% 0;
+        }
+      }
+
+      @keyframes bootstrap-spin {
+        0% {
+          transform: rotate(0deg);
+        }
+        100% {
+          transform: rotate(360deg);
         }
       }
 
@@ -350,7 +440,7 @@
     <script>
       (function () {
         var SLOW_BOOT_THRESHOLD_MS = 12000;
-        window.__bootstrapLoaderTimeout = null;
+        var loaderState = window.__bootstrapLoaderState || null;
 
         function markSlowBoot() {
           var loader = document.getElementById('app-bootstrap-loader');
@@ -374,6 +464,17 @@
         }
 
         window.addEventListener('DOMContentLoaded', function () {
+          var loader = document.getElementById('app-bootstrap-loader');
+          var loaderMessage = loaderState && typeof loaderState.message === 'string'
+            ? loaderState.message.trim()
+            : '';
+          if (loader && loaderMessage) {
+            var text = loader.querySelector('.loading-text');
+            if (text) {
+              text.textContent = loaderMessage;
+            }
+          }
+
           var retryButton = document.querySelector('[data-loader-retry]');
           if (retryButton) {
             retryButton.addEventListener('click', function () {
@@ -396,6 +497,9 @@
       aria-live="polite"
       aria-label="Application loading"
     >
+      <div class="loading-indicator loading-indicator--spinner" aria-hidden="true">
+        <div class="loading-spinner"></div>
+      </div>
       <div class="loading-skeleton loading-skeleton--app" aria-hidden="true">
         <div class="skeleton-app-header">
           <div class="skeleton-app-brand">

--- a/js/app.js
+++ b/js/app.js
@@ -34,6 +34,7 @@ import { hasAnyClaimables } from './utils/claims.js';
 import { isUserRejection } from './utils/ui.js';
 import { escapeHtml } from './utils/html.js';
 
+const BOOTSTRAP_LOADER_STATE_KEY = 'whaleswapBootstrapLoader';
 class App {
 	constructor() {
 		this.isInitializing = false;
@@ -650,11 +651,71 @@ class App {
 	getSkeletonLoaderMarkup(message = 'Loading...', variant = 'form') {
 		return `
 			${this.getSkeletonMarkupByVariant(variant)}
-			<div class="loading-text">${message}</div>
+			<div class="loading-text">${escapeHtml(message)}</div>
 		`;
 	}
 
-	showGlobalLoader(message = 'Loading WhaleSwap...') {
+	getGlobalLoaderMarkup(message = 'Loading WhaleSwap...', variant = 'app') {
+		return `
+			<div class="loading-indicator loading-indicator--spinner" aria-hidden="true">
+				<div class="loading-spinner"></div>
+			</div>
+			${this.getSkeletonMarkupByVariant(variant)}
+			<div class="loading-text">${escapeHtml(message)}</div>
+		`;
+	}
+
+	resolveGlobalLoaderMode(mode = null) {
+		if (mode === 'spinner' || mode === 'skeleton') {
+			return mode;
+		}
+		if (this.globalLoader?.dataset?.loaderMode === 'spinner') {
+			return 'spinner';
+		}
+		return document.documentElement?.dataset?.bootstrapLoaderMode === 'spinner'
+			? 'spinner'
+			: 'skeleton';
+	}
+
+	ensureGlobalLoaderMarkup(loader, message = 'Loading WhaleSwap...') {
+		if (!loader) return;
+		if (loader.querySelector('.loading-indicator--spinner') && loader.querySelector('.loading-skeleton')) {
+			return;
+		}
+		loader.innerHTML = this.getGlobalLoaderMarkup(message, 'app');
+	}
+
+	setGlobalLoaderMode(mode = null) {
+		if (!this.globalLoader) return;
+		const resolvedMode = this.resolveGlobalLoaderMode(mode);
+		this.globalLoader.dataset.loaderMode = resolvedMode;
+		this.globalLoader.classList.toggle('loading-overlay--spinner', resolvedMode === 'spinner');
+		if (document.documentElement?.dataset) {
+			document.documentElement.dataset.bootstrapLoaderMode = resolvedMode;
+		}
+	}
+
+	persistBootstrapLoaderState({ mode = 'spinner', message = 'Loading WhaleSwap...' } = {}) {
+		try {
+			const historyState = window.history?.state || {};
+			window.history?.replaceState?.(
+				{
+					...historyState,
+					[BOOTSTRAP_LOADER_STATE_KEY]: {
+						mode: mode === 'spinner' ? 'spinner' : 'skeleton',
+						message: String(message || '')
+					}
+				},
+				'',
+				window.location.href
+			);
+		} catch (error) {
+			this.debug('Failed to persist bootstrap loader state:', error);
+		}
+	}
+
+	showGlobalLoader(message = 'Loading WhaleSwap...', options = {}) {
+		const { mode = null } = options;
 		if (window.__bootstrapLoaderTimeout) {
 			clearTimeout(window.__bootstrapLoaderTimeout);
 			window.__bootstrapLoaderTimeout = null;
@@ -662,6 +723,8 @@ class App {
 
 		if (this.globalLoader?.parentElement) {
 			this.globalLoader.classList.remove('is-slow');
+			this.ensureGlobalLoaderMarkup(this.globalLoader, message);
+			this.setGlobalLoaderMode(mode);
 			const hint = this.globalLoader.querySelector('[data-loader-hint]');
 			const retry = this.globalLoader.querySelector('[data-loader-retry]');
 			if (hint) hint.hidden = true;
@@ -675,6 +738,8 @@ class App {
 		if (existingLoader) {
 			this.globalLoader = existingLoader;
 			this.globalLoader.classList.remove('is-slow');
+			this.ensureGlobalLoaderMarkup(this.globalLoader, message);
+			this.setGlobalLoaderMode(mode);
 			const hint = this.globalLoader.querySelector('[data-loader-hint]');
 			const retry = this.globalLoader.querySelector('[data-loader-retry]');
 			if (hint) hint.hidden = true;
@@ -685,9 +750,10 @@ class App {
 
 		const loader = document.createElement('div');
 		loader.className = 'loading-overlay loading-overlay--global';
-		loader.innerHTML = this.getSkeletonLoaderMarkup(message, 'app');
+		loader.innerHTML = this.getGlobalLoaderMarkup(message, 'app');
 		document.body.appendChild(loader);
 		this.globalLoader = loader;
+		this.setGlobalLoaderMode(mode);
 		return loader;
 	}
 
@@ -708,6 +774,9 @@ class App {
 			this.globalLoader.remove();
 		}
 		this.globalLoader = null;
+		if (document.documentElement?.dataset) {
+			document.documentElement.dataset.bootstrapLoaderMode = 'skeleton';
+		}
 	}
 
 	getSelectedNetwork() {
@@ -968,7 +1037,7 @@ class App {
 				});
 			}
 
-			this.showGlobalLoader(`Switching to ${getNetworkLabel(targetNetwork)}...`);
+			this.showGlobalLoader(`Switching to ${getNetworkLabel(targetNetwork)}...`, { mode: 'spinner' });
 			this.loadingOverlay = this.globalLoader;
 
 			try {
@@ -1083,11 +1152,10 @@ class App {
 		const wallet = this.ctx?.getWallet?.();
 		const isConnected = !!wallet?.isWalletConnected?.() && !!wallet?.getSigner?.();
 		if (!isConnected) {
-			try {
-				window.location.reload();
-			} catch (error) {
-				console.warn('[App] Reload failed after disconnected network selection:', error);
-			}
+			triggerPageReloadWithSwitchFallback({
+				loaderMode: 'spinner',
+				loaderMessage: `Switching to ${getNetworkLabel(network)}...`
+			});
 			return;
 		}
 
@@ -1660,6 +1728,31 @@ class App {
 		);
 	}
 
+	prepareForNetworkReload(options = {}) {
+		const {
+			loaderMode = 'spinner',
+			loaderMessage = 'Switching network...'
+		} = options;
+
+		this.persistBootstrapLoaderState({
+			mode: loaderMode,
+			message: loaderMessage
+		});
+		this.showGlobalLoader(loaderMessage, { mode: loaderMode });
+
+		try {
+			if (this.currentTab !== 'create-order') {
+				return;
+			}
+
+			const createOrderComponent = this.components?.['create-order'];
+			if (typeof createOrderComponent?.persistFormStateForReload === 'function') {
+				createOrderComponent.persistFormStateForReload();
+			}
+		} catch (error) {
+			this.debug('Failed to preserve create order form state before reload:', error);
+		}
+	}
 	showLoader(container = document.body) {
 		const loader = document.createElement('div');
 		loader.className = 'loading-overlay';
@@ -2061,6 +2154,19 @@ function syncAddNetworkButtonVisibility() {
 		: 'Add Network';
 }
 
+function triggerPageReloadWithSwitchFallback(options = {}) {
+	try {
+		window.app?.prepareForNetworkReload?.(options);
+	} catch (error) {
+		console.warn('[App] Failed to preserve state before reload:', error);
+	}
+
+	try {
+		window.location.reload();
+	} catch (error) {
+		console.warn('[App] Reload failed after network switch:', error);
+	}
+}
 function syncNetworkBadgeFromState() {
 	if (!networkBadge) return;
 

--- a/tests/app.networkReloadLoader.test.js
+++ b/tests/app.networkReloadLoader.test.js
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import '../js/app.js';
+
+const BOOTSTRAP_LOADER_STATE_KEY = 'whaleswapBootstrapLoader';
+
+function setupBootstrapLoaderDom() {
+	document.body.innerHTML = `
+		<div id="app-bootstrap-loader" class="loading-overlay--global" role="status">
+			<div class="loading-text">Loading WhaleSwap...</div>
+			<div class="loading-hint" data-loader-hint hidden></div>
+			<button class="loading-retry" type="button" data-loader-retry hidden>Retry</button>
+		</div>
+	`;
+}
+
+afterEach(() => {
+	document.body.innerHTML = '';
+	document.documentElement.dataset.bootstrapLoaderMode = 'skeleton';
+	window.history.replaceState({}, '', '/');
+	vi.restoreAllMocks();
+});
+
+describe('App bootstrap loader transitions', () => {
+	it('keeps the skeleton loader by default on initial load', () => {
+		const AppCtor = window.app.constructor;
+		const app = new AppCtor();
+
+		const loader = app.showGlobalLoader('Loading WhaleSwap...');
+
+		expect(loader.classList.contains('loading-overlay--spinner')).toBe(false);
+		expect(loader.querySelector('.loading-skeleton--app')).toBeTruthy();
+		expect(loader.querySelector('.loading-indicator--spinner')).toBeTruthy();
+		expect(loader.querySelector('.loading-text').textContent).toBe('Loading WhaleSwap...');
+	});
+
+	it('persists spinner mode for the next load during network-triggered reloads', () => {
+		const AppCtor = window.app.constructor;
+		const app = new AppCtor();
+		const persistFormStateForReload = vi.fn();
+
+		setupBootstrapLoaderDom();
+		app.globalLoader = document.getElementById('app-bootstrap-loader');
+		app.currentTab = 'create-order';
+		app.components = {
+			'create-order': {
+				persistFormStateForReload
+			}
+		};
+
+		app.prepareForNetworkReload();
+
+		const loaderState = window.history.state?.[BOOTSTRAP_LOADER_STATE_KEY];
+		expect(loaderState).toEqual({
+			mode: 'spinner',
+			message: 'Switching network...'
+		});
+		expect(app.globalLoader.classList.contains('loading-overlay--spinner')).toBe(true);
+		expect(app.globalLoader.querySelector('.loading-indicator--spinner')).toBeTruthy();
+		expect(app.globalLoader.querySelector('.loading-text').textContent).toBe('Switching network...');
+		expect(persistFormStateForReload).toHaveBeenCalledTimes(1);
+	});
+});


### PR DESCRIPTION
## Summary
- keep the full bootstrap skeleton for first-load app startup
- show a lightweight translucent spinner overlay for non-initial network loading instead of reusing the page skeleton
- preserve the existing connected network transition behavior from `main` while updating the loader treatment
- add regression coverage for the one-shot bootstrap loader mode

## Testing
- npm test

Closes #140
