### PR TITLE
Fix connected startup default tab selection

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -124,6 +124,19 @@ class App {
 			|| tabId === 'cleanup-orders';
 	}
 
+	getInitialRenderState() {
+		const wallet = this.ctx?.getWallet?.();
+		const isInitiallyConnected = !!wallet?.getSigner?.();
+		const isInitialNetworkMatch = this.isWalletOnSelectedNetwork(
+			this.ctx?.getWalletChainId?.() || walletManager.chainId || null
+		);
+
+		return {
+			defaultTab: isInitiallyConnected ? 'create-order' : 'view-orders',
+			hasInitialConnectedContext: isInitiallyConnected && isInitialNetworkMatch,
+		};
+	}
+
 	getTabButton(tabId) {
 		return document.querySelector(`.tab-button[data-tab="${tabId}"]`);
 	}
@@ -1307,15 +1320,11 @@ class App {
 				}
 			});
 
-			// Treat presence of signer as connected for initial render to avoid flicker,
-			// but only enable connected UX when wallet chain matches selected chain.
-			const wallet = this.ctx.getWallet();
-			const isInitiallyConnected = !!wallet?.getSigner?.();
-			const isInitialNetworkMatch = this.isWalletOnSelectedNetwork(
-				this.ctx.getWalletChainId() || walletManager.chainId || null
-			);
-			const hasInitialConnectedContext = isInitiallyConnected && isInitialNetworkMatch;
-			this.currentTab = hasInitialConnectedContext ? 'create-order' : 'view-orders';
+			const {
+				defaultTab,
+				hasInitialConnectedContext,
+			} = this.getInitialRenderState();
+			this.currentTab = defaultTab;
 
 				// Add wallet connection state handler
 				walletManager.addListener(async (event, data) => {

--- a/tests/app.connectedDefaultTab.test.js
+++ b/tests/app.connectedDefaultTab.test.js
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import '../js/app.js';
+import { getNetworkBySlug } from '../js/config/networks.js';
+
+const POLYGON_CHAIN_ID = '0x89';
+const ETHEREUM_CHAIN_ID = '0x1';
+
+function createApp() {
+	const AppCtor = window.app.constructor;
+	const app = new AppCtor();
+
+	app.ctx = {
+		getWallet: () => ({
+			getSigner: () => null,
+		}),
+		getWalletChainId: () => null,
+	};
+	app.getSelectedNetwork = () => getNetworkBySlug('polygon');
+	window.app = app;
+
+	return app;
+}
+
+afterEach(() => {
+	document.body.innerHTML = '';
+});
+
+describe('App initial default tab behavior', () => {
+	it('defaults to create-order for a connected wallet even when the wallet is on a different network', () => {
+		const app = createApp();
+		app.ctx = {
+			getWallet: () => ({
+				getSigner: () => ({})
+			}),
+			getWalletChainId: () => ETHEREUM_CHAIN_ID,
+		};
+
+		expect(app.getInitialRenderState()).toEqual({
+			defaultTab: 'create-order',
+			hasInitialConnectedContext: false,
+		});
+	});
+
+	it('defaults to view-orders when no wallet is connected', () => {
+		const app = createApp();
+		app.ctx = {
+			getWallet: () => ({
+				getSigner: () => null,
+			}),
+			getWalletChainId: () => POLYGON_CHAIN_ID,
+		};
+
+		expect(app.getInitialRenderState()).toEqual({
+			defaultTab: 'view-orders',
+			hasInitialConnectedContext: false,
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- default the startup tab to `create-order` whenever the wallet is connected, even if the wallet is on a different network
- keep the existing `hasInitialConnectedContext` network-match behavior for the current connected/read-only bootstrapping logic
- add regression coverage for connected-on-wrong-network and disconnected startup tab selection

## Testing
- `npm test -- tests/app.connectedDefaultTab.test.js tests/app.networkTransition.test.js tests/app.orderTabVisibility.test.js`
- `npm test`

Closes #147
