### PR TITLE
Decouple connected UI state from wallet network

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -79,36 +79,17 @@ class App {
 
 	async handleWalletConnectEvent(data = {}) {
 		const walletChainId = data?.chainId || walletManager.chainId || null;
-		const selectedNetwork = this.getSelectedNetwork();
-		const walletNetwork = getNetworkById(walletChainId);
-		const shouldAttemptSwitch = !walletNetwork || walletNetwork.slug !== selectedNetwork.slug;
 		const shouldShowCompatibilityNotice = data?.userInitiated === true;
 
 		clearNetworkSetupRequired();
 		this.ctx.setWalletChainId(walletChainId);
 		syncNetworkBadgeFromState();
 
-		if (shouldAttemptSwitch) {
-			this.updateTabVisibility(false);
-			await this.refreshAdminTabVisibility();
-			await this.refreshClaimTabVisibility();
-			await this.refreshOrderTabVisibility();
-			const switched = await this.switchWalletToNetwork(selectedNetwork, {
-				source: 'wallet-connect',
-				selectedChainChanged: false,
-				previousSelectedNetwork: selectedNetwork,
-			});
-			if (switched && shouldShowCompatibilityNotice) {
-				this.showWarning(WALLET_COMPATIBILITY_NOTICE);
-			}
-			return;
-		}
-
 		if (shouldShowCompatibilityNotice) {
 			this.showWarning(WALLET_COMPATIBILITY_NOTICE);
 		}
 
-		this.debug('Wallet connected on selected chain, reinitializing components...');
+		this.debug('Wallet connected, reinitializing components...');
 		this.updateTabVisibility(true);
 		await this.refreshAdminTabVisibility();
 		await this.refreshClaimTabVisibility();
@@ -122,6 +103,15 @@ class App {
 			|| tabId === 'my-orders'
 			|| tabId === 'taker-orders'
 			|| tabId === 'cleanup-orders';
+	}
+
+	isWalletConnectedForUi() {
+		const wallet = this.ctx?.getWallet?.() || walletManager;
+		return Boolean(
+			wallet?.isWalletConnected?.()
+			|| wallet?.getAccount?.()
+			|| wallet?.getSigner?.()
+		);
 	}
 
 	getTabButton(tabId) {
@@ -263,7 +253,7 @@ class App {
 			const isConnected = !!wallet?.isWalletConnected?.();
 			const account = wallet?.getAccount?.();
 
-			if (!isConnected || !account || !this.isWalletOnSelectedNetwork()) {
+			if (!isConnected || !account) {
 				return await applyVisibility(noOrderTabsVisibility);
 			}
 
@@ -380,7 +370,7 @@ class App {
 			const isConnected = !!wallet?.isWalletConnected?.();
 			const userAddress = wallet?.getAccount?.();
 
-				if (!isConnected || !userAddress || !this.isWalletOnSelectedNetwork()) {
+				if (!isConnected || !userAddress) {
 					if (isCurrentRequest()) {
 						this.clearClaimVisibilityRetryTimer();
 						this.resetClaimVisibilityRetryBackoff();
@@ -1307,14 +1297,8 @@ class App {
 				}
 			});
 
-			// Treat presence of signer as connected for initial render to avoid flicker,
-			// but only enable connected UX when wallet chain matches selected chain.
-			const wallet = this.ctx.getWallet();
-			const isInitiallyConnected = !!wallet?.getSigner?.();
-			const isInitialNetworkMatch = this.isWalletOnSelectedNetwork(
-				this.ctx.getWalletChainId() || walletManager.chainId || null
-			);
-			const hasInitialConnectedContext = isInitiallyConnected && isInitialNetworkMatch;
+			const isInitiallyConnected = this.isWalletConnectedForUi();
+			const hasInitialConnectedContext = isInitiallyConnected;
 			this.currentTab = hasInitialConnectedContext ? 'create-order' : 'view-orders';
 
 				// Add wallet connection state handler
@@ -1352,14 +1336,6 @@ class App {
 							this.ctx.setWalletChainId(walletManager.chainId || null);
 							syncNetworkBadgeFromState();
 
-								if (!this.isWalletOnSelectedNetwork()) {
-									this.updateTabVisibility(false);
-									await this.refreshAdminTabVisibility();
-									await this.refreshClaimTabVisibility();
-									await this.refreshOrderTabVisibility();
-									break;
-								}
-
 								this.debug('Account changed, reinitializing components...');
 								this.updateTabVisibility(true);
 								await this.refreshAdminTabVisibility();
@@ -1394,7 +1370,7 @@ class App {
 										walletChainId,
 									});
 								} else {
-								this.updateTabVisibility(false);
+								this.updateTabVisibility(true);
 								await this.refreshAdminTabVisibility();
 								await this.refreshClaimTabVisibility();
 								await this.refreshOrderTabVisibility();
@@ -1497,7 +1473,7 @@ class App {
 				this.scheduleClaimTabVisibilityRefresh();
 			};
 
-			// Update initial tab visibility based on connection + selected-chain match
+			// Update initial tab visibility based on wallet connection only.
 			this.updateTabVisibility(hasInitialConnectedContext);
 			// Do not block first paint on owner check/network calls.
 			Promise.resolve()
@@ -1527,7 +1503,7 @@ class App {
 		// Initialize theme handling
 		this.initializeTheme();
 
-		// Prefer signer presence + selected-chain match for initial render
+		// Treat connected wallets as connected UI even if the wallet chain differs.
 		const initialReadOnlyMode = !hasInitialConnectedContext;
 		this.updateGlobalLoaderText('Preparing interface...');
 		await this.initializeComponents(initialReadOnlyMode);

--- a/tests/app.connectedContext.test.js
+++ b/tests/app.connectedContext.test.js
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import '../js/app.js';
+import { getNetworkBySlug } from '../js/config/networks.js';
+
+const POLYGON_CHAIN_ID = '0x89';
+const BNB_CHAIN_ID = '0x38';
+
+function createApp() {
+	const AppCtor = window.app.constructor;
+	const app = new AppCtor();
+
+	app.ctx = {
+		getWallet: () => ({
+			isWalletConnected: () => false,
+			getSigner: () => null,
+			getAccount: () => null,
+		}),
+		getWalletChainId: () => null,
+		setWalletChainId: vi.fn(),
+	};
+	app.getSelectedNetwork = vi.fn(() => getNetworkBySlug('polygon'));
+	app.updateTabVisibility = vi.fn();
+	app.refreshAdminTabVisibility = vi.fn(async () => false);
+	app.refreshClaimTabVisibility = vi.fn(async () => false);
+	app.refreshOrderTabVisibility = vi.fn(async () => ({ showMyOrders: false, showInvitedOrders: false }));
+	app.reinitializeComponents = vi.fn(async () => {});
+	app.switchWalletToNetwork = vi.fn(async () => true);
+	app.showWarning = vi.fn();
+	window.app = app;
+
+	return app;
+}
+
+afterEach(() => {
+	document.body.innerHTML = '';
+	vi.restoreAllMocks();
+});
+
+describe('App connected state behavior', () => {
+	it('treats a wallet account on a different network as connected for initial UI state', () => {
+		const app = createApp();
+		app.ctx = {
+			...app.ctx,
+			getWallet: () => ({
+				isWalletConnected: () => true,
+				getSigner: () => null,
+				getAccount: () => '0x1234',
+			}),
+			getWalletChainId: () => BNB_CHAIN_ID,
+		};
+
+		expect(app.isWalletConnectedForUi()).toBe(true);
+	});
+
+	it('does not auto-switch the wallet on connect when the wallet is on a different network', async () => {
+		const app = createApp();
+
+		await app.handleWalletConnectEvent({
+			chainId: BNB_CHAIN_ID,
+			userInitiated: true,
+		});
+
+		expect(app.switchWalletToNetwork).not.toHaveBeenCalled();
+		expect(app.ctx.setWalletChainId).toHaveBeenCalledWith(BNB_CHAIN_ID);
+		expect(app.updateTabVisibility).toHaveBeenCalledWith(true);
+		expect(app.refreshClaimTabVisibility).toHaveBeenCalledTimes(1);
+		expect(app.refreshOrderTabVisibility).toHaveBeenCalledTimes(1);
+		expect(app.reinitializeComponents).toHaveBeenCalledWith(true);
+	});
+
+	it('keeps disconnected startup in read-only mode', () => {
+		const app = createApp();
+		app.ctx = {
+			...app.ctx,
+			getWallet: () => ({
+				isWalletConnected: () => false,
+				getSigner: () => null,
+				getAccount: () => null,
+			}),
+			getWalletChainId: () => POLYGON_CHAIN_ID,
+		};
+
+		expect(app.isWalletConnectedForUi()).toBe(false);
+	});
+});

--- a/tests/app.orderTabVisibility.test.js
+++ b/tests/app.orderTabVisibility.test.js
@@ -106,6 +106,20 @@ describe('App order tab visibility behavior', () => {
         expect(app.getTabButton('taker-orders').style.display).toBe('block');
     });
 
+    it('shows connected order tabs even when the wallet is on a different network', async () => {
+        setupTabDom();
+        const { app } = createAppWithContext({
+            networkMatch: false,
+            orders: [{ maker: ACCOUNT, taker: OTHER }]
+        });
+
+        const result = await app.refreshOrderTabVisibility();
+
+        expect(result).toEqual({ showMyOrders: true, showInvitedOrders: false });
+        expect(app.getTabButton('my-orders').style.display).toBe('block');
+        expect(app.getTabButton('taker-orders').style.display).toBe('none');
+    });
+
     it('redirects to View Orders if current order tab becomes hidden', async () => {
         setupTabDom();
         const { app } = createAppWithContext({


### PR DESCRIPTION
## Summary
- treat connected UI state as wallet connection only, instead of coupling it to wallet/network match
- stop auto-switching the wallet during connect and keep switch/add-network behavior in write-time flows
- keep connected order and claim visibility available when data can be resolved from app RPC/WebSocket plus wallet address

## Testing
- `npm test -- tests/app.connectedContext.test.js tests/app.orderTabVisibility.test.js tests/app.networkTransition.test.js`
- `npm test`

Closes #147
Closes #154

Supersedes #156
