### PR TITLE
Use firstOrderId as the lower bound for order sync

### DIFF
--- a/js/services/WebSocket.js
+++ b/js/services/WebSocket.js
@@ -1010,18 +1010,31 @@ export class WebSocketService {
      * High-level helper: fetch orders in batches using multicall with fallback.
      * Returns an array of decoded orders (without timing expansion).
      */
-    async fetchOrdersBatched(totalOrders, batchSize = 50) {
+    async fetchOrdersInRange(startOrderId, endOrderIdExclusive, batchSize = 50) {
         const all = [];
         if (!this.contract) {
             throw new Error('Contract not initialized. Call initialize() first.');
         }
+        const normalizedStartOrderId = Math.max(0, Number(startOrderId) || 0);
+        const normalizedEndOrderIdExclusive = Math.max(
+            normalizedStartOrderId,
+            Number(endOrderIdExclusive) || 0
+        );
+        const totalOrders = Math.max(0, normalizedEndOrderIdExclusive - normalizedStartOrderId);
         const totalBatches = Math.ceil(totalOrders / batchSize);
-        this.debug(`Batched order fetch: ${totalOrders} orders in ${totalBatches} batches of ${batchSize}`);
+        const lastScannedOrderId = totalOrders > 0
+            ? normalizedEndOrderIdExclusive - 1
+            : normalizedStartOrderId;
+        this.debug(
+            `Batched order fetch: scanning ${totalOrders} order slots `
+            + `from ${normalizedStartOrderId} to ${lastScannedOrderId} `
+            + `in ${totalBatches} batches of ${batchSize}`
+        );
         let fetchedSoFar = 0;
 
         for (let batch = 0; batch < totalBatches; batch++) {
-            const startIndex = batch * batchSize;
-            const endIndex = Math.min(startIndex + batchSize, totalOrders);
+            const startIndex = normalizedStartOrderId + (batch * batchSize);
+            const endIndex = Math.min(startIndex + batchSize, normalizedEndOrderIdExclusive);
             this.debug(`Fetching batch ${batch + 1}/${totalBatches} (orders ${startIndex}-${endIndex - 1})`);
             let batchOrders = await this.fetchOrdersViaMulticall(startIndex, endIndex);
             if (!batchOrders) {
@@ -1133,19 +1146,36 @@ export class WebSocketService {
                 }
                 this.debug('Starting order sync with contract:', this.contract.address);
 
+                let firstOrderId = 0;
                 let nextOrderId = 0;
+                try {
+                    firstOrderId = await this.contract.firstOrderId();
+                    this.debug('firstOrderId result:', firstOrderId.toString());
+                } catch (error) {
+                    this.debug('firstOrderId call failed, using default value:', error);
+                }
                 try {
                     nextOrderId = await this.contract.nextOrderId();
                     this.debug('nextOrderId result:', nextOrderId.toString());
                 } catch (error) {
                     this.debug('nextOrderId call failed, using default value:', error);
                 }
+                const startOrderId = Math.max(0, Number(firstOrderId) || 0);
+                const endOrderIdExclusive = Math.max(startOrderId, Number(nextOrderId) || 0);
+                this.debug('Resolved order sync range:', {
+                    startOrderId,
+                    endOrderIdExclusive
+                });
 
                 // Clear existing cache before sync
                 this.orderCache.clear();
 
                 // Use optimized batched fetch (multicall with fallback)
-                const fetchedOrders = await this.fetchOrdersBatched(Number(nextOrderId), 50);
+                const fetchedOrders = await this.fetchOrdersInRange(
+                    startOrderId,
+                    endOrderIdExclusive,
+                    50
+                );
 
                 // Enrich with timings and populate cache
                 for (const o of fetchedOrders) {

--- a/tests/websocket.orderSyncRange.test.js
+++ b/tests/websocket.orderSyncRange.test.js
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ethers } from 'ethers';
+import { WebSocketService } from '../js/services/WebSocket.js';
+
+describe('WebSocketService order sync range', () => {
+    it('uses firstOrderId as the lower bound for initial sync', async () => {
+        const service = new WebSocketService();
+        service.contract = {
+            address: '0x0000000000000000000000000000000000000001',
+            firstOrderId: vi.fn().mockResolvedValue(ethers.BigNumber.from(7)),
+            nextOrderId: vi.fn().mockResolvedValue(ethers.BigNumber.from(12))
+        };
+
+        const fetchOrdersInRangeSpy = vi
+            .spyOn(service, 'fetchOrdersInRange')
+            .mockResolvedValue([
+                {
+                    id: 7,
+                    maker: '0x0000000000000000000000000000000000000011',
+                    taker: ethers.constants.AddressZero,
+                    sellToken: '0x00000000000000000000000000000000000000a1',
+                    sellAmount: ethers.BigNumber.from(10),
+                    buyToken: '0x00000000000000000000000000000000000000b1',
+                    buyAmount: ethers.BigNumber.from(20),
+                    timestamp: 1700000000,
+                    status: 'Active'
+                }
+            ]);
+        vi.spyOn(service, 'calculateDealMetrics').mockImplementation(async (orderData) => ({
+            ...orderData,
+            dealMetrics: { deal: 1 }
+        }));
+        vi.spyOn(service, 'setupEventListeners').mockResolvedValue();
+        vi.spyOn(service, 'notifySubscribers').mockImplementation(() => {});
+
+        const syncResult = await service.syncAllOrders();
+
+        expect(syncResult).toBe(true);
+        expect(service.contract.firstOrderId).toHaveBeenCalledTimes(1);
+        expect(service.contract.nextOrderId).toHaveBeenCalledTimes(1);
+        expect(fetchOrdersInRangeSpy).toHaveBeenCalledWith(7, 12, 50);
+        expect(service.orderCache.has(7)).toBe(true);
+    });
+
+    it('batches reads from a non-zero start order id', async () => {
+        const service = new WebSocketService();
+        service.contract = {
+            address: '0x0000000000000000000000000000000000000001'
+        };
+
+        const multicallSpy = vi
+            .spyOn(service, 'fetchOrdersViaMulticall')
+            .mockResolvedValueOnce([{ id: 5 }, { id: 6 }])
+            .mockResolvedValueOnce([{ id: 7 }, { id: 8 }]);
+        vi.spyOn(service, 'notifySubscribers').mockImplementation(() => {});
+
+        const orders = await service.fetchOrdersInRange(5, 9, 2);
+
+        expect(multicallSpy).toHaveBeenNthCalledWith(1, 5, 7);
+        expect(multicallSpy).toHaveBeenNthCalledWith(2, 7, 9);
+        expect(orders).toEqual([{ id: 5 }, { id: 6 }, { id: 7 }, { id: 8 }]);
+    });
+});


### PR DESCRIPTION
## Summary
- use `firstOrderId` and `nextOrderId` to narrow the initial order sync range
- rename the batch helper to `fetchOrdersInRange` so the range-based behavior is explicit
- add regression coverage for non-zero order sync lower bounds

## Testing
- `npm test -- tests/websocket.orderSyncRange.test.js tests/allowedTokensUpdated.behavior.test.js`

Closes #151
