### PR TITLE
Clear values after creating an order

### DIFF
--- a/js/components/CreateOrder.js
+++ b/js/components/CreateOrder.js
@@ -1627,7 +1627,20 @@ export class CreateOrder extends BaseComponent {
             takerAddressInput.value = '';
         }
         
-        this.debug('Cleared order input values (amounts and taker address)');
+        // Clear USD displays
+        const sellUsdDisplay = document.getElementById('sellAmountUSD');
+        const buyUsdDisplay = document.getElementById('buyAmountUSD');
+        
+        if (sellUsdDisplay) {
+            sellUsdDisplay.textContent = '≈ $0.00';
+            setVisibility(sellUsdDisplay, false);
+        }
+        if (buyUsdDisplay) {
+            buyUsdDisplay.textContent = '≈ $0.00';
+            setVisibility(buyUsdDisplay, false);
+        }
+        
+        this.debug('Cleared order input values (amounts, taker address, and USD displays)');
     }
 
     setTransactionProgressSession(session) {


### PR DESCRIPTION
## Summary
Implements clear values functionality after successful order creation.

## Changes
- Clear order input values (amounts) after successful order creation
- Keep selected tokens unchanged
- Only clear values when order is successfully created
- Do not clear values if order creation fails or modal is closed early

## Related Issue
Fixes #159

## Testing
- [ ] Test successful order creation clears values
- [ ] Test failed order creation preserves values
- [ ] Test early modal close preserves values
- [ ] Test tokens remain selected after clear