### PR TITLE
Fix startup order snapshot by moving reads off WebSocket

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1218,10 +1218,11 @@ class App {
 			this.updateGlobalLoaderText('Initializing wallet...');
 			await this.initializeWalletManager();
 			this.alignSelectedNetworkToRestoredWallet();
+			const hasInitialConnectedContext = this.isWalletConnectedForUi();
 			this.updateGlobalLoaderText('Initializing pricing...');
 			await this.initializePricingService();
 			this.updateGlobalLoaderText('Connecting to order feed...');
-			await this.initializeWebSocket();
+			await this.initializeWebSocket({ awaitReady: hasInitialConnectedContext });
 
 			// Initialize CreateOrder first
 			this.components = {
@@ -1297,8 +1298,6 @@ class App {
 				}
 			});
 
-			const isInitiallyConnected = this.isWalletConnectedForUi();
-			const hasInitialConnectedContext = isInitiallyConnected;
 			this.currentTab = hasInitialConnectedContext ? 'create-order' : 'view-orders';
 
 				// Add wallet connection state handler
@@ -1574,7 +1573,8 @@ class App {
 		}
 	}
 
-	async initializeWebSocket() {
+	async initializeWebSocket(options = {}) {
+		const { awaitReady = true } = options;
 		try {
 			this.debug('Initializing WebSocket...');
 			// Initialize WebSocket with injected pricingService
@@ -1612,9 +1612,23 @@ class App {
 				} catch (_) {}
 			});
 
-			const wsInitialized = await webSocketService.initialize();
-			if (!wsInitialized) {
-				this.debug('WebSocket initialization failed, falling back to HTTP');
+			const initializationPromise = webSocketService.initialize();
+			if (awaitReady) {
+				const wsInitialized = await initializationPromise;
+				if (!wsInitialized) {
+					this.debug('WebSocket initialization failed, falling back to HTTP');
+				}
+			} else {
+				this.debug('Starting WebSocket initialization in background');
+				void initializationPromise
+					.then((wsInitialized) => {
+						if (!wsInitialized) {
+							this.debug('Background WebSocket initialization failed, HTTP snapshot mode remains active');
+						}
+					})
+					.catch((error) => {
+						this.debug('Background WebSocket initialization error:', error);
+					});
 			}
 
 			this.debug('WebSocket initialized');
@@ -1628,19 +1642,17 @@ class App {
 			this.debug('Initializing components in ' +
 				(readOnlyMode ? 'read-only' : 'connected') + ' mode');
 
-			// In read-only mode, initialize the tabs that should always be visible
+			// In read-only mode, initialize only the active tab.
+			// Off-screen tabs initialize lazily when the user opens them.
 			if (readOnlyMode) {
-				const readOnlyTabs = ['intro', 'create-order', 'view-orders', 'cleanup-orders', 'contract-params'];
-				for (const tabId of readOnlyTabs) {
-					const component = this.components[tabId];
-					if (component && typeof component.initialize === 'function') {
-						this.debug(`Initializing read-only component: ${tabId}`);
-						try {
-							await component.initialize(readOnlyMode);
-							this.tabReady.add(tabId);
-						} catch (error) {
-							console.error(`[App] Error initializing ${tabId}:`, error);
-						}
+				const currentComponent = this.components[this.currentTab];
+				if (currentComponent && typeof currentComponent.initialize === 'function') {
+					this.debug(`Initializing read-only component: ${this.currentTab}`);
+					try {
+						await currentComponent.initialize(readOnlyMode);
+						this.tabReady.add(this.currentTab);
+					} catch (error) {
+						console.error(`[App] Error initializing ${this.currentTab}:`, error);
 					}
 				}
 			} else {

--- a/js/config/networks.js
+++ b/js/config/networks.js
@@ -144,9 +144,9 @@ const testNetworkConfig = {
         contractAddress: "0x0aB6ca718d12349B5477fD480a13F5e21a786222",
         contractABI: CONTRACT_ABI,
         explorer: "https://amoy.polygonscan.com",
-        rpcUrl: "https://rpc-amoy.polygon.technology",
+        rpcUrl: "https://polygon-amoy-bor-rpc.publicnode.com",
         fallbackRpcUrls: [
-            "https://polygon-amoy-bor-rpc.publicnode.com"
+            "https://rpc-amoy.polygon.technology"
         ],
         chainId: "0x13882",
         nativeCurrency: {

--- a/js/services/ContractService.js
+++ b/js/services/ContractService.js
@@ -58,28 +58,51 @@ class ContractService {
     }
 
     /**
+     * Get configured HTTP RPC URLs for the active network.
+     * @returns {string[]} Primary RPC followed by configured fallbacks
+     */
+    getHttpRpcUrls() {
+        const net = getNetworkConfig();
+        return [net?.rpcUrl, ...(net?.fallbackRpcUrls || [])].filter(Boolean);
+    }
+
+    /**
      * Run a read-only contract call via HTTP RPC (tries primary rpcUrl then fallbackRpcUrls).
      * Used for allowed-token reads to avoid WebSocket timeout on startup.
-     * @param {function(ethers.Contract): Promise<any>} readFn - Function that receives the HTTP-backed contract and returns the read result
+     * @param {function({ provider: ethers.providers.JsonRpcProvider, contract: ethers.Contract|null, url: string, networkConfig: object }): Promise<any>} readFn
+     * @param {Object} options
+     * @param {string} [options.contractAddress]
+     * @param {Array|Object} [options.contractAbi]
      * @returns {Promise<any>} Result of readFn(contract)
-     * @private
      */
-    async _readViaHttpRpc(readFn) {
+    async readViaHttpRpc(readFn, options = {}) {
         if (!this.initialized) {
             throw new Error('Contract service not initialized');
         }
+
         const net = getNetworkConfig();
-        const rpcUrls = [net?.rpcUrl, ...(net?.fallbackRpcUrls || [])].filter(Boolean);
+        const rpcUrls = this.getHttpRpcUrls();
         if (rpcUrls.length === 0) {
             throw new Error('No HTTP RPC URL configured for current network');
         }
+
+        const contractAddress = options.contractAddress ?? net?.contractAddress ?? null;
+        const contractAbi = options.contractAbi ?? net?.contractABI ?? null;
         let lastErr;
+
         for (const url of rpcUrls) {
             try {
                 this.debug(`Trying HTTP RPC: ${url}`);
                 const httpProvider = new ethers.providers.JsonRpcProvider(url);
-                const httpContract = new ethers.Contract(net.contractAddress, net.contractABI, httpProvider);
-                const result = await readFn(httpContract);
+                const httpContract = contractAddress && contractAbi
+                    ? new ethers.Contract(contractAddress, contractAbi, httpProvider)
+                    : null;
+                const result = await readFn({
+                    provider: httpProvider,
+                    contract: httpContract,
+                    url,
+                    networkConfig: net
+                });
                 this.debug(`HTTP RPC succeeded: ${url}`);
                 return result;
             } catch (e) {
@@ -89,6 +112,10 @@ class ContractService {
             }
         }
         throw lastErr || new Error('All HTTP RPC URLs failed');
+    }
+
+    async _readViaHttpRpc(readFn) {
+        return this.readViaHttpRpc(({ contract }) => readFn(contract));
     }
 
     /**

--- a/js/services/MulticallService.js
+++ b/js/services/MulticallService.js
@@ -17,7 +17,7 @@ const MULTICALL2_ABI = [
  * Get a Multicall2 contract instance for the current network
  * Returns null if provider or multicall address is not available
  */
-function getMulticallContract() {
+function getMulticallContract(providerOverride = null) {
 	try {
 		const networkCfg = getNetworkConfig();
 		const multicallAddress = networkCfg.multicallAddress;
@@ -26,7 +26,7 @@ function getMulticallContract() {
 			return null;
 		}
 
-		const provider = contractService.getProvider();
+		const provider = providerOverride || contractService.getProvider();
 		if (!provider) {
 			debug('No provider available for Multicall');
 			return null;
@@ -42,12 +42,12 @@ function getMulticallContract() {
 /**
  * Execute a batch of read-only calls via Multicall2.
  * @param {Array<{ target: string, callData: string }>} calls
- * @param {{ requireSuccess?: boolean }} options
+ * @param {{ requireSuccess?: boolean, provider?: ethers.providers.Provider|null }} options
  * @returns {Promise<Array<{ success: boolean, returnData: string }>> | null} Returns null if multicall is not available
  */
 export async function tryAggregate(calls, options = {}) {
 	const requireSuccess = options.requireSuccess === true;
-	const mc = getMulticallContract();
+	const mc = getMulticallContract(options.provider || null);
 	if (!mc) return null; // Signal to fallback
 
 	if (!Array.isArray(calls) || calls.length === 0) {
@@ -65,12 +65,11 @@ export async function tryAggregate(calls, options = {}) {
 /**
  * Helper to check if multicall is configured and provider is available.
  */
-export function isMulticallAvailable() {
+export function isMulticallAvailable(providerOverride = null) {
 	try {
 		const networkCfg = getNetworkConfig();
-		return !!(networkCfg.multicallAddress && contractService.getProvider());
+		return !!(networkCfg.multicallAddress && (providerOverride || contractService.getProvider()));
 	} catch {
 		return false;
 	}
 }
-

--- a/js/services/WebSocket.js
+++ b/js/services/WebSocket.js
@@ -2,6 +2,7 @@ import { ethers } from 'ethers';
 import { ORDER_CONSTANTS } from '../config/index.js';
 import { getNetworkConfig } from '../config/networks.js';
 import { tryAggregate as multicallTryAggregate, isMulticallAvailable } from './MulticallService.js';
+import { contractService } from './ContractService.js';
 import { erc20Abi } from '../abi/erc20.js';
 import { createLogger } from './LogService.js';
 import { tokenIconService } from './TokenIconService.js';
@@ -28,6 +29,7 @@ export class WebSocketService {
         this.requestQueue = [];
         this.processingQueue = false;
         this.lastRequestTime = 0;
+        this.nextRequestStartAt = 0;
         this.minRequestInterval = 100; // Increase from 100ms to 500ms between requests
         this.maxConcurrentRequests = 2; // Reduce from 3 to 1 concurrent request
         this.activeRequests = 0;
@@ -54,6 +56,9 @@ export class WebSocketService {
         // Order sync lifecycle state
         this.orderSyncPromise = null;
         this.hasCompletedOrderSync = false;
+        this.lifecycleVersion = 0;
+        this.eventListenersAttached = false;
+        this.eventListenersContract = null;
 
         // Contract disabled-state cache
         this.contractDisabledCache = null;
@@ -412,37 +417,136 @@ export class WebSocketService {
         return null;
     }
 
-    async queueRequest(callback) {
-        while (this.activeRequests >= this.maxConcurrentRequests) {
-            await new Promise(resolve => setTimeout(resolve, 100)); // Increase wait time
+    getNetworkContextKey() {
+        const config = getNetworkConfig();
+        return `${config?.chainId || 'unknown'}:${config?.contractAddress || 'unknown'}`;
+    }
+
+    isStaleWork(lifecycleVersion, networkContextKey) {
+        return this.lifecycleVersion !== lifecycleVersion
+            || this.getNetworkContextKey() !== networkContextKey;
+    }
+
+    processRequestQueue() {
+        if (this.processingQueue) {
+            return;
         }
-        
-        const now = Date.now();
-        const timeSinceLastRequest = now - this.lastRequestTime;
-        
-        if (timeSinceLastRequest < this.minRequestInterval) {
-            await new Promise(resolve => 
-                setTimeout(resolve, this.minRequestInterval - timeSinceLastRequest)
-            );
-        }
-        
+
+        this.processingQueue = true;
         try {
-            this.activeRequests++;
-            this.debug(`Making request (active: ${this.activeRequests})`);
-            const result = await callback();
-            this.lastRequestTime = Date.now();
-            return result;
-        } catch (error) {
-            if (error?.error?.code === -32005) {
-                this.warn('Rate limit hit, waiting before retry...');
-                await new Promise(resolve => setTimeout(resolve, 2000));
-                return this.queueRequest(callback);
+            while (this.activeRequests < this.maxConcurrentRequests && this.requestQueue.length > 0) {
+                const job = this.requestQueue.shift();
+                this.startQueuedRequest(job);
             }
-            this.error('Request failed:', error);
-            throw error;
         } finally {
-            this.activeRequests--;
+            this.processingQueue = false;
         }
+    }
+
+    startQueuedRequest(job) {
+        const now = Date.now();
+        const scheduledStartAt = Math.max(now, this.nextRequestStartAt);
+        const delayMs = Math.max(0, scheduledStartAt - now);
+        this.nextRequestStartAt = scheduledStartAt + this.minRequestInterval;
+        this.activeRequests++;
+
+        setTimeout(async () => {
+            try {
+                this.lastRequestTime = Date.now();
+                this.debug(`Making request (active: ${this.activeRequests})`);
+                const result = await job.callback();
+                job.resolve(result);
+            } catch (error) {
+                if (error?.error?.code === -32005) {
+                    this.warn('Rate limit hit, waiting before retry...');
+                    setTimeout(() => {
+                        this.requestQueue.unshift(job);
+                        this.processRequestQueue();
+                    }, 2000);
+                    return;
+                }
+
+                this.error('Request failed:', error);
+                job.reject(error);
+            } finally {
+                this.activeRequests = Math.max(0, this.activeRequests - 1);
+                this.processRequestQueue();
+            }
+        }, delayMs);
+    }
+
+    async queueRequest(callback) {
+        return await new Promise((resolve, reject) => {
+            this.requestQueue.push({ callback, resolve, reject });
+            this.processRequestQueue();
+        });
+    }
+
+    async ensureEventListenersReady() {
+        if (!this.isInitialized || !this.provider || !this.contract) {
+            return false;
+        }
+
+        if (this.eventListenersAttached && this.eventListenersContract === this.contract) {
+            return true;
+        }
+
+        await this.setupEventListeners(this.contract);
+        this.eventListenersAttached = true;
+        this.eventListenersContract = this.contract;
+        return true;
+    }
+
+    attachEventListenersAfterRealtimeReady(realtimeReadyPromise, lifecycleVersion, networkContextKey) {
+        void Promise.resolve(realtimeReadyPromise)
+            .then(async (ready) => {
+                if (!ready || this.isStaleWork(lifecycleVersion, networkContextKey)) {
+                    return;
+                }
+
+                await this.ensureEventListenersReady();
+            })
+            .catch((error) => {
+                this.debug('Realtime initialization failed after snapshot sync:', error);
+            });
+    }
+
+    async loadStartupSnapshotViaHttp() {
+        contractService.initialize({ webSocket: this });
+
+        return await contractService.readViaHttpRpc(async ({ contract, provider }) => {
+            if (!contract) {
+                throw new Error('HTTP contract not available');
+            }
+
+            const [firstOrderId, nextOrderId, orderExpiry, gracePeriod] = await Promise.all([
+                contract.firstOrderId(),
+                contract.nextOrderId(),
+                contract.ORDER_EXPIRY(),
+                contract.GRACE_PERIOD()
+            ]);
+
+            const startOrderId = Math.max(0, Number(firstOrderId) || 0);
+            const endOrderIdExclusive = Math.max(startOrderId, Number(nextOrderId) || 0);
+            const fetchedOrders = await this.fetchOrdersInRange(
+                startOrderId,
+                endOrderIdExclusive,
+                50,
+                { contract, provider }
+            );
+
+            return {
+                provider,
+                contract,
+                firstOrderId,
+                nextOrderId,
+                orderExpiry,
+                gracePeriod,
+                startOrderId,
+                endOrderIdExclusive,
+                fetchedOrders
+            };
+        });
     }
 
     withTimeout(promise, timeoutMs, message) {
@@ -884,25 +988,31 @@ export class WebSocketService {
      * If multicall is unavailable, returns null to signal fallback.
      * Uses this.contract.interface so decode shape always matches the deployment ABI.
      */
-    async fetchOrdersViaMulticall(startIndex, endIndex) {
+    async fetchOrdersViaMulticall(startIndex, endIndex, options = {}) {
         try {
-            if (!isMulticallAvailable()) {
+            const contract = options.contract || this.contract;
+            const provider = options.provider || contract?.provider || this.provider;
+            if (!contract) {
+                throw new Error('Contract not initialized. Call initialize() first.');
+            }
+
+            if (!isMulticallAvailable(provider)) {
                 this.debug('Multicall not available, skipping multicall path');
                 return null;
             }
 
-            const iface = this.contract.interface;
+            const iface = contract.interface;
             const calls = [];
             for (let i = startIndex; i < endIndex; i++) {
                 calls.push({
-                    target: this.contract.address,
+                    target: contract.address,
                     callData: iface.encodeFunctionData('orders', [i])
                 });
             }
 
             // Try once, then retry once on failure before falling back
             let results = await this.withTimeout(
-                multicallTryAggregate(calls, { requireSuccess: false }),
+                multicallTryAggregate(calls, { requireSuccess: false, provider }),
                 5000,
                 'multicall timeout'
             );
@@ -911,7 +1021,7 @@ export class WebSocketService {
                 await new Promise(r => setTimeout(r, 150));
                 try {
                     results = await this.withTimeout(
-                        multicallTryAggregate(calls, { requireSuccess: false }),
+                        multicallTryAggregate(calls, { requireSuccess: false, provider }),
                         5000,
                         'multicall timeout'
                     );
@@ -964,7 +1074,12 @@ export class WebSocketService {
     /**
      * Fallback: fetch orders individually with small concurrency.
      */
-    async fetchOrdersIndividually(startIndex, endIndex, concurrency = 3) {
+    async fetchOrdersIndividually(startIndex, endIndex, concurrency = 3, options = {}) {
+        const contract = options.contract || this.contract;
+        if (!contract) {
+            throw new Error('Contract not initialized. Call initialize() first.');
+        }
+
         const indices = [];
         for (let i = startIndex; i < endIndex; i++) indices.push(i);
         const results = [];
@@ -976,7 +1091,7 @@ export class WebSocketService {
                 if (idx >= indices.length) break;
                 const orderId = indices[idx];
                 try {
-                    const order = await this.contract.orders(orderId);
+                    const order = await contract.orders(orderId);
                     if (order.maker === ethers.constants.AddressZero) {
                         continue;
                     }
@@ -1010,9 +1125,11 @@ export class WebSocketService {
      * High-level helper: fetch orders in batches using multicall with fallback.
      * Returns an array of decoded orders (without timing expansion).
      */
-    async fetchOrdersInRange(startOrderId, endOrderIdExclusive, batchSize = 50) {
+    async fetchOrdersInRange(startOrderId, endOrderIdExclusive, batchSize = 50, options = {}) {
         const all = [];
-        if (!this.contract) {
+        const contract = options.contract || this.contract;
+        const provider = options.provider || contract?.provider || this.provider;
+        if (!contract) {
             throw new Error('Contract not initialized. Call initialize() first.');
         }
         const normalizedStartOrderId = Math.max(0, Number(startOrderId) || 0);
@@ -1036,9 +1153,9 @@ export class WebSocketService {
             const startIndex = normalizedStartOrderId + (batch * batchSize);
             const endIndex = Math.min(startIndex + batchSize, normalizedEndOrderIdExclusive);
             this.debug(`Fetching batch ${batch + 1}/${totalBatches} (orders ${startIndex}-${endIndex - 1})`);
-            let batchOrders = await this.fetchOrdersViaMulticall(startIndex, endIndex);
+            let batchOrders = await this.fetchOrdersViaMulticall(startIndex, endIndex, { contract, provider });
             if (!batchOrders) {
-                batchOrders = await this.fetchOrdersIndividually(startIndex, endIndex, 3);
+                batchOrders = await this.fetchOrdersIndividually(startIndex, endIndex, 3, { contract });
             }
             all.push(...batchOrders);
             fetchedSoFar += batchOrders.length;
@@ -1100,14 +1217,20 @@ export class WebSocketService {
             this.lastChainTimeBootstrapFailureAtMonotonicMs = null;
             this.orderSyncPromise = null;
             this.hasCompletedOrderSync = false;
+            this.eventListenersAttached = false;
+            this.eventListenersContract = null;
+            this.lifecycleVersion++;
             this.isInitialized = false;
             this.provider = null;
             this.contract = null;
             this.initializationPromise = null;
             this.orderExpiry = null;
             this.gracePeriod = null;
+            this.requestQueue = [];
+            this.processingQueue = false;
             this.activeRequests = 0;
             this.lastRequestTime = 0;
+            this.nextRequestStartAt = 0;
             this.resetContractDisabledStateCache();
             this.healthCheckPromise = null;
             this.reconnectPromise = null;
@@ -1128,8 +1251,6 @@ export class WebSocketService {
         if (!triggerIfNeeded) {
             return false;
         }
-        // Ensure WebSocket is initialized before syncing orders
-        await this.waitForInitialization();
         return this.syncAllOrders();
     }
 
@@ -1140,54 +1261,47 @@ export class WebSocketService {
         }
 
         this.orderSyncPromise = (async () => {
-            this.debug('Starting order sync with existing contract...');
+            this.debug('Starting startup order snapshot sync...');
+            const lifecycleVersion = this.lifecycleVersion;
+            const networkContextKey = this.getNetworkContextKey();
+            const realtimeReadyPromise = this.initialize().catch((error) => {
+                this.debug('Realtime WebSocket initialization failed during startup sync:', error);
+                return false;
+            });
 
             try {
-                if (!this.contract) {
-                    throw new Error('Contract not initialized. Call initialize() first.');
+                const snapshot = await this.loadStartupSnapshotViaHttp();
+                if (this.isStaleWork(lifecycleVersion, networkContextKey)) {
+                    this.debug('Discarding stale startup snapshot after lifecycle/network change');
+                    return false;
                 }
-                this.debug('Starting order sync with contract:', this.contract.address);
 
-                let firstOrderId = 0;
-                let nextOrderId = 0;
-                try {
-                    firstOrderId = await this.contract.firstOrderId();
-                    this.debug('firstOrderId result:', firstOrderId.toString());
-                } catch (error) {
-                    this.debug('firstOrderId call failed, using default value:', error);
-                }
-                try {
-                    nextOrderId = await this.contract.nextOrderId();
-                    this.debug('nextOrderId result:', nextOrderId.toString());
-                } catch (error) {
-                    this.debug('nextOrderId call failed, using default value:', error);
-                }
-                const startOrderId = Math.max(0, Number(firstOrderId) || 0);
-                const endOrderIdExclusive = Math.max(startOrderId, Number(nextOrderId) || 0);
+                this.orderExpiry = snapshot.orderExpiry;
+                this.gracePeriod = snapshot.gracePeriod;
                 this.debug('Resolved order sync range:', {
-                    startOrderId,
-                    endOrderIdExclusive
+                    startOrderId: snapshot.startOrderId,
+                    endOrderIdExclusive: snapshot.endOrderIdExclusive
                 });
 
                 // Clear existing cache before sync
                 this.orderCache.clear();
 
-                // Use optimized batched fetch (multicall with fallback)
-                const fetchedOrders = await this.fetchOrdersInRange(
-                    startOrderId,
-                    endOrderIdExclusive,
-                    50
-                );
-
                 // Enrich with timings and populate cache
-                for (const o of fetchedOrders) {
+                for (const o of snapshot.fetchedOrders) {
+                    if (this.isStaleWork(lifecycleVersion, networkContextKey)) {
+                        this.debug('Discarding stale startup snapshot while populating cache');
+                        return false;
+                    }
+
                     const orderData = {
                         ...o,
                         timings: this.buildOrderTimings(o.timestamp)
                     };
                     // Calculate deal metrics for the order
                     try {
-                        const enrichedOrderData = await this.calculateDealMetrics(orderData);
+                        const enrichedOrderData = await this.calculateDealMetrics(orderData, {
+                            provider: snapshot.provider
+                        });
                         this.orderCache.set(o.id, enrichedOrderData);
                         this.debug('Added order to cache with deal metrics:', enrichedOrderData);
                     } catch (error) {
@@ -1206,15 +1320,20 @@ export class WebSocketService {
                 this.debug('Order sync complete. Cache size:', this.orderCache.size);
                 // Set flag BEFORE notifying subscribers so UI components see correct state
                 this.hasCompletedOrderSync = true;
-                this.debug('Setting up event listeners...');
-                await this.setupEventListeners(this.contract);
                 this.notifySubscribers('orderSyncComplete', Object.fromEntries(this.orderCache));
+                this.attachEventListenersAfterRealtimeReady(
+                    realtimeReadyPromise,
+                    lifecycleVersion,
+                    networkContextKey
+                );
                 return true;
             } catch (error) {
                 this.debug('Order sync failed:', error);
-                this.orderCache.clear();
-                this.hasCompletedOrderSync = false;
-                this.notifySubscribers('orderSyncComplete', {});
+                if (!this.isStaleWork(lifecycleVersion, networkContextKey)) {
+                    this.orderCache.clear();
+                    this.hasCompletedOrderSync = false;
+                    this.notifySubscribers('orderSyncComplete', {});
+                }
                 return false;
             } finally {
                 this.orderSyncPromise = null;
@@ -1366,9 +1485,14 @@ export class WebSocketService {
     }
 
     // Deal = buy USD value / sell USD value using token-normalized (decimal-adjusted) amounts.
-    async calculateDealMetrics(orderData) {
-        const buyTokenInfo = await this.getTokenInfo(orderData.buyToken); // maker wants to receive this
-        const sellTokenInfo = await this.getTokenInfo(orderData.sellToken); // maker offers this
+    async calculateDealMetrics(orderData, options = {}) {
+        const tokenProvider = options.provider || null;
+        const buyTokenInfo = await this.getTokenInfo(orderData.buyToken, {
+            provider: tokenProvider
+        }); // maker wants to receive this
+        const sellTokenInfo = await this.getTokenInfo(orderData.sellToken, {
+            provider: tokenProvider
+        }); // maker offers this
 
         const buyTokenDecimals = Number.isInteger(buyTokenInfo?.decimals) ? buyTokenInfo.decimals : 18;
         const sellTokenDecimals = Number.isInteger(sellTokenInfo?.decimals) ? sellTokenInfo.decimals : 18;
@@ -1459,7 +1583,7 @@ export class WebSocketService {
         };
     }
 
-    async getTokenInfo(tokenAddress) {
+    async getTokenInfo(tokenAddress, options = {}) {
         try {
             // Normalize address to lowercase for consistent comparison
             const normalizedAddress = tokenAddress.toLowerCase();
@@ -1472,8 +1596,13 @@ export class WebSocketService {
 
             // 2. Fetch from contract using queueRequest
             this.debug('Fetching token info from contract:', normalizedAddress);
-            return await this.queueRequest(async () => {
-                const contract = new ethers.Contract(tokenAddress, erc20Abi, this.provider);
+            const provider = options.provider || this.provider;
+            if (!provider) {
+                throw new Error('Provider not initialized');
+            }
+
+            const readTokenInfo = async () => {
+                const contract = new ethers.Contract(tokenAddress, erc20Abi, provider);
                 const [symbol, decimals, name] = await Promise.all([
                     contract.symbol(),
                     contract.decimals(),
@@ -1502,7 +1631,13 @@ export class WebSocketService {
                 this.debug('Added token to cache:', tokenInfo);
 
                 return tokenInfo;
-            });
+            };
+
+            if (provider !== this.provider || options.queue === false) {
+                return await readTokenInfo();
+            }
+
+            return await this.queueRequest(readTokenInfo);
 
         } catch (error) {
             this.debug('Error getting token info:', error);
@@ -1619,6 +1754,8 @@ export class WebSocketService {
                 this.provider = null;
                 this.contract = null;
                 this.initializationPromise = null;
+                this.eventListenersAttached = false;
+                this.eventListenersContract = null;
                 this.lastKnownChainTimestamp = null;
                 this.chainTimeSyncedAtMonotonicMs = null;
                 this.chainTimeSyncPromise = null;

--- a/js/services/WebSocket.js
+++ b/js/services/WebSocket.js
@@ -427,6 +427,20 @@ export class WebSocketService {
             || this.getNetworkContextKey() !== networkContextKey;
     }
 
+    isProviderReadError(error) {
+        const errorCode = error?.code || error?.error?.code || '';
+        const errorMessage = String(
+            error?.message
+            || error?.reason
+            || error?.error?.message
+            || ''
+        );
+
+        return errorCode === 'NETWORK_ERROR'
+            || errorCode === 'SERVER_ERROR'
+            || /could not detect network|missing response/i.test(errorMessage);
+    }
+
     processRequestQueue() {
         if (this.processingQueue) {
             return;
@@ -1109,6 +1123,10 @@ export class WebSocketService {
                         orderCreationFee: order.orderCreationFee
                     });
                 } catch (e) {
+                    if (this.isProviderReadError(e)) {
+                        this.debug(`Provider error reading order ${orderId} via fallback`, e);
+                        throw e;
+                    }
                     this.debug(`Failed to read order ${orderId} via fallback`, e);
                 }
             }

--- a/js/services/WebSocket.js
+++ b/js/services/WebSocket.js
@@ -1648,7 +1648,6 @@ export class WebSocketService {
                 decimals: 18,
                 name: 'Unknown Token'
             };
-            this.tokenCache.set(tokenAddress.toLowerCase(), fallback);
             return fallback;
         }
     }

--- a/tests/websocket.orderSyncRange.test.js
+++ b/tests/websocket.orderSyncRange.test.js
@@ -98,4 +98,48 @@ describe('WebSocketService startup order sync', () => {
         );
         expect(orders).toEqual([{ id: 5 }, { id: 6 }, { id: 7 }, { id: 8 }]);
     });
+
+    it('rethrows provider errors from individual order reads so HTTP RPC fallback can engage', async () => {
+        const service = new WebSocketService();
+        const providerError = Object.assign(new Error('could not detect network'), {
+            code: 'NETWORK_ERROR'
+        });
+        const contract = {
+            orders: vi.fn().mockRejectedValue(providerError)
+        };
+
+        await expect(
+            service.fetchOrdersIndividually(0, 1, 1, { contract })
+        ).rejects.toBe(providerError);
+    });
+
+    it('continues past per-order call exceptions during individual fallback reads', async () => {
+        const service = new WebSocketService();
+        const validOrder = {
+            maker: '0x0000000000000000000000000000000000000011',
+            taker: ethers.constants.AddressZero,
+            sellToken: '0x00000000000000000000000000000000000000a1',
+            sellAmount: ethers.BigNumber.from(10),
+            buyToken: '0x00000000000000000000000000000000000000b1',
+            buyAmount: ethers.BigNumber.from(20),
+            timestamp: ethers.BigNumber.from(1700000000),
+            status: 0,
+            feeToken: '0x00000000000000000000000000000000000000c1',
+            orderCreationFee: ethers.BigNumber.from(1)
+        };
+        const callException = Object.assign(new Error('execution reverted'), {
+            code: 'CALL_EXCEPTION'
+        });
+        const contract = {
+            orders: vi
+                .fn()
+                .mockResolvedValueOnce(validOrder)
+                .mockRejectedValueOnce(callException)
+        };
+
+        const orders = await service.fetchOrdersIndividually(0, 2, 1, { contract });
+
+        expect(orders).toHaveLength(1);
+        expect(orders[0]).toEqual(expect.objectContaining({ id: 0 }));
+    });
 });

--- a/tests/websocket.orderSyncRange.test.js
+++ b/tests/websocket.orderSyncRange.test.js
@@ -1,45 +1,69 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ethers } from 'ethers';
 import { WebSocketService } from '../js/services/WebSocket.js';
 
-describe('WebSocketService order sync range', () => {
-    it('uses firstOrderId as the lower bound for initial sync', async () => {
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe('WebSocketService startup order sync', () => {
+    it('syncs the startup snapshot over HTTP without requiring a websocket contract', async () => {
         const service = new WebSocketService();
-        service.contract = {
-            address: '0x0000000000000000000000000000000000000001',
-            firstOrderId: vi.fn().mockResolvedValue(ethers.BigNumber.from(7)),
-            nextOrderId: vi.fn().mockResolvedValue(ethers.BigNumber.from(12))
+        const httpProvider = { name: 'http-provider' };
+        const order = {
+            id: 7,
+            maker: '0x0000000000000000000000000000000000000011',
+            taker: ethers.constants.AddressZero,
+            sellToken: '0x00000000000000000000000000000000000000a1',
+            sellAmount: ethers.BigNumber.from(10),
+            buyToken: '0x00000000000000000000000000000000000000b1',
+            buyAmount: ethers.BigNumber.from(20),
+            timestamp: 1700000000,
+            status: 'Active'
         };
 
-        const fetchOrdersInRangeSpy = vi
-            .spyOn(service, 'fetchOrdersInRange')
-            .mockResolvedValue([
-                {
-                    id: 7,
-                    maker: '0x0000000000000000000000000000000000000011',
-                    taker: ethers.constants.AddressZero,
-                    sellToken: '0x00000000000000000000000000000000000000a1',
-                    sellAmount: ethers.BigNumber.from(10),
-                    buyToken: '0x00000000000000000000000000000000000000b1',
-                    buyAmount: ethers.BigNumber.from(20),
-                    timestamp: 1700000000,
-                    status: 'Active'
-                }
-            ]);
-        vi.spyOn(service, 'calculateDealMetrics').mockImplementation(async (orderData) => ({
-            ...orderData,
-            dealMetrics: { deal: 1 }
-        }));
-        vi.spyOn(service, 'setupEventListeners').mockResolvedValue();
+        vi.spyOn(service, 'initialize').mockResolvedValue(false);
+        vi.spyOn(service, 'loadStartupSnapshotViaHttp').mockResolvedValue({
+            provider: httpProvider,
+            startOrderId: 7,
+            endOrderIdExclusive: 12,
+            orderExpiry: ethers.BigNumber.from(3600),
+            gracePeriod: ethers.BigNumber.from(300),
+            fetchedOrders: [order]
+        });
+        vi.spyOn(service, 'calculateDealMetrics').mockImplementation(async (orderData, options = {}) => {
+            expect(options.provider).toBe(httpProvider);
+            return {
+                ...orderData,
+                dealMetrics: { deal: 1 }
+            };
+        });
         vi.spyOn(service, 'notifySubscribers').mockImplementation(() => {});
+        const ensureEventListenersReadySpy = vi
+            .spyOn(service, 'ensureEventListenersReady')
+            .mockResolvedValue(true);
 
         const syncResult = await service.syncAllOrders();
 
         expect(syncResult).toBe(true);
-        expect(service.contract.firstOrderId).toHaveBeenCalledTimes(1);
-        expect(service.contract.nextOrderId).toHaveBeenCalledTimes(1);
-        expect(fetchOrdersInRangeSpy).toHaveBeenCalledWith(7, 12, 50);
+        expect(service.loadStartupSnapshotViaHttp).toHaveBeenCalledTimes(1);
         expect(service.orderCache.has(7)).toBe(true);
+        expect(service.hasCompletedOrderSync).toBe(true);
+        expect(service.orderExpiry.toString()).toBe('3600');
+        expect(service.gracePeriod.toString()).toBe('300');
+        expect(ensureEventListenersReadySpy).not.toHaveBeenCalled();
+    });
+
+    it('triggers order sync without waiting for websocket initialization first', async () => {
+        const service = new WebSocketService();
+        const waitForInitializationSpy = vi.spyOn(service, 'waitForInitialization');
+        const syncAllOrdersSpy = vi.spyOn(service, 'syncAllOrders').mockResolvedValue(true);
+
+        const syncResult = await service.waitForOrderSync({ triggerIfNeeded: true });
+
+        expect(syncResult).toBe(true);
+        expect(waitForInitializationSpy).not.toHaveBeenCalled();
+        expect(syncAllOrdersSpy).toHaveBeenCalledTimes(1);
     });
 
     it('batches reads from a non-zero start order id', async () => {
@@ -56,8 +80,22 @@ describe('WebSocketService order sync range', () => {
 
         const orders = await service.fetchOrdersInRange(5, 9, 2);
 
-        expect(multicallSpy).toHaveBeenNthCalledWith(1, 5, 7);
-        expect(multicallSpy).toHaveBeenNthCalledWith(2, 7, 9);
+        expect(multicallSpy).toHaveBeenNthCalledWith(
+            1,
+            5,
+            7,
+            expect.objectContaining({
+                contract: service.contract
+            })
+        );
+        expect(multicallSpy).toHaveBeenNthCalledWith(
+            2,
+            7,
+            9,
+            expect.objectContaining({
+                contract: service.contract
+            })
+        );
         expect(orders).toEqual([{ id: 5 }, { id: 6 }, { id: 7 }, { id: 8 }]);
     });
 });

--- a/tests/websocket.queueRequest.test.js
+++ b/tests/websocket.queueRequest.test.js
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { WebSocketService } from '../js/services/WebSocket.js';
+
+describe('WebSocketService queueRequest', () => {
+    it('enforces the configured concurrency limit', async () => {
+        const service = new WebSocketService();
+        service.minRequestInterval = 0;
+        service.maxConcurrentRequests = 2;
+
+        let activeRequests = 0;
+        let maxObservedConcurrency = 0;
+
+        const results = await Promise.all(
+            Array.from({ length: 6 }, (_, index) => service.queueRequest(async () => {
+                activeRequests++;
+                maxObservedConcurrency = Math.max(maxObservedConcurrency, activeRequests);
+                await new Promise((resolve) => setTimeout(resolve, 20));
+                activeRequests--;
+                return index;
+            }))
+        );
+
+        expect(results).toEqual([0, 1, 2, 3, 4, 5]);
+        expect(maxObservedConcurrency).toBeLessThanOrEqual(2);
+    });
+});


### PR DESCRIPTION
## Summary
This PR narrows the startup stability fix to the core order-loading path.

The main change is that the initial order snapshot now loads over HTTP RPC instead of depending on WebSocket health. WebSocket initialization still happens for live events, but it is no longer the transport used for the startup order snapshot itself.

This PR is **partial work toward #171**, not a full implementation of that tracker.

Refs #171

## What This PR Covers
- Add reusable HTTP RPC read plumbing in `ContractService`.
- Make multicall provider-injectable so startup reads can use HTTP instead of inheriting the WebSocket provider.
- Move startup order snapshot reads in `WebSocketService` to HTTP:
  - `firstOrderId`
  - `nextOrderId`
  - `ORDER_EXPIRY`
  - `GRACE_PERIOD`
  - batched order reads via multicall
  - per-order fallback reads
- Keep order enrichment on the same HTTP transport by allowing `getTokenInfo()` / deal-metric token metadata reads to use the snapshot provider.
- Stop `waitForOrderSync()` from waiting on full WebSocket initialization before the snapshot begins.
- Start WebSocket initialization in the background for the disconnected / read-only boot path.
- Fix `queueRequest()` so the concurrency limit is actually enforced.
- Add tests covering:
  - startup snapshot without requiring a websocket-backed contract
  - order sync trigger without waiting on websocket initialization
  - injected-provider multicall batching
  - queue concurrency enforcement

## Mapping To #171
Issue #171 describes the minimum viable startup stability set as `01 + 02 + 03`.

This PR intentionally does **not** implement that exact bundle.

### Covered from #171
- `01: HTTP read foundation`
- `02: Order snapshot over HTTP`

### Narrow extra coverage included here
- A focused slice of `05: Fix WebSocket queue correctness`
  - included because `queueRequest()` is a standalone correctness bug and small enough to land safely here
- A focused slice of `06: Decouple startup from WebSocket readiness`
  - included only for the read-only / disconnected boot path so the startup snapshot can actually begin before websocket readiness

## What This PR Intentionally Leaves Out
- `03: ContractParams over HTTP`
- `04: Fee config and startup token metadata over HTTP` outside the order snapshot enrichment path
- the broader connected-startup decoupling for `CreateOrder`
- `07: post-connect reconcile and partial-failure semantics`

## Why Those Parts Are Left Out
- `ContractParams` is still a separate write scope and should be reviewed on its own.
- Fee-config and broader token-metadata migration touches multiple components (`Intro`, `CreateOrder`, `Cleanup`, `Admin`) and expands this from a startup-order fix into a broader startup-read refactor.
- The connected boot path still waits for WebSocket because `CreateOrder` currently depends on `ws.contract` / `ws.provider`; changing that in this PR would significantly widen scope.
- I did **not** add the “one extra snapshot reconcile pass” from the planning doc because a blind second snapshot merge is not obviously safe. That needs explicit merge semantics or a stronger replay strategy before it should land.

## Resulting Scope After This PR
What should improve immediately:
- the initial order snapshot no longer depends on WebSocket health
- multicall timeout fallback no longer falls back to the same unhealthy websocket transport
- disconnected / read-only boot no longer has to wait for websocket readiness before the order snapshot can start
- websocket queue pressure is reduced because the limiter now actually enforces concurrency

What can still still happen after this PR:
- `ContractParams` can still use WebSocket when that tab is opened
- fee-config reads in other components can still use WebSocket
- connected `CreateOrder` boot still depends on WebSocket readiness
- there is still no post-connect reconcile or partial-failure classification layer

## Testing
- `npm test -- tests/websocket.orderSyncRange.test.js tests/websocket.queueRequest.test.js`
- `npm test`

Full Vitest suite passed locally: `37` test files, `138` tests.