### PR TITLE
Move ContractParams to HTTP RPC

### DIFF
--- a/js/components/ContractParams.js
+++ b/js/components/ContractParams.js
@@ -1,5 +1,6 @@
 import { BaseComponent } from './BaseComponent.js';
 import { createLogger } from '../services/LogService.js';
+import { contractService } from '../services/ContractService.js';
 import { ethers } from 'ethers';
 
 export class ContractParams extends BaseComponent {
@@ -244,11 +245,12 @@ export class ContractParams extends BaseComponent {
         };
         let successCount = 0;
 
+        // Use HTTP RPC for contract parameter reads (avoids WebSocket timeout issues)
         await Promise.all(
             Object.entries(paramMethods).map(async ([key, method]) => {
                 try {
                     params[key] = await this.readWithTimeout(
-                        () => ws.queueRequest(() => contract[method]()),
+                        () => contractService._readViaHttpRpc((c) => c[method]()),
                         method
                     );
                     successCount++;
@@ -318,9 +320,10 @@ export class ContractParams extends BaseComponent {
             await Promise.all(
                 Array.from(feeTokenSet).map(async (tokenAddress) => {
                     try {
+                        // Use HTTP RPC for accumulated fees read
                         const [amount, tokenInfo] = await Promise.all([
                             this.readWithTimeout(
-                                () => contract.accumulatedFeesByToken(tokenAddress),
+                                () => contractService._readViaHttpRpc((c) => c.accumulatedFeesByToken(tokenAddress)),
                                 `accumulated fees for ${tokenAddress}`,
                             ),
                             this.readWithTimeout(

--- a/js/components/ContractParams.js
+++ b/js/components/ContractParams.js
@@ -246,6 +246,7 @@ export class ContractParams extends BaseComponent {
         let successCount = 0;
 
         // Use HTTP RPC for contract parameter reads (avoids WebSocket timeout issues)
+        console.log('[CONTRACT_PARAMS] Starting HTTP RPC reads for contract parameters');
         await Promise.all(
             Object.entries(paramMethods).map(async ([key, method]) => {
                 try {

--- a/js/config/debug.js
+++ b/js/config/debug.js
@@ -15,6 +15,8 @@ export const DEBUG_CONFIG = {
     TOAST: false, // Enable toast debugging for testing
     PRICING_DEFAULT_TO_ONE: false, // Default missing prices to 1 for testing, false for production
     ADMIN_BYPASS_OWNER_CHECK: false, // Temporary: bypass owner gating for Admin tab access
+    CONTRACT_SERVICE: true, // Enable to debug HTTP RPC calls
+    CONTRACT_PARAMS: true, // Enable to debug contract params reads
     // Add more specific flags as needed
 };
 

--- a/js/services/ContractService.js
+++ b/js/services/ContractService.js
@@ -115,6 +115,7 @@ class ContractService {
     }
 
     async _readViaHttpRpc(readFn) {
+        console.log('[CONTRACT_SERVICE] _readViaHttpRpc called');
         return this.readViaHttpRpc(({ contract }) => readFn(contract));
     }
 


### PR DESCRIPTION
## Summary
- Move ContractParams.js to use HTTP RPC instead of WebSocket for contract parameter reads
- Addresses issue #171 item 3

## Changes
- Update ContractParams.js to use HTTP RPC for all contract parameter reads
- Remove dependency on ws.queueRequest() for startup reads

## Related
- Part of #171 (item 3)
- Depends on PR #172 (HTTP read foundation)