### PR TITLE
Fix #174: Unify token metadata cache ownership and lifetime

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -33,7 +33,7 @@ import { createAppContext, setGlobalContext } from './services/AppContext.js';
 import { hasAnyClaimables } from './utils/claims.js';
 import { isUserRejection } from './utils/ui.js';
 import { escapeHtml } from './utils/html.js';
-import { clearTokenCaches } from './utils/contractTokens.js';
+import { clearBalanceCache } from './utils/contractTokens.js';
 
 const BOOTSTRAP_LOADER_STATE_KEY = 'whaleswapBootstrapLoader';
 class App {
@@ -931,8 +931,9 @@ class App {
 	}
 
 	async recreateNetworkServices() {
-		// Clear token caches on network switch (issue #174)
-		clearTokenCaches();
+		// Clear balance cache on network switch (issue #174)
+		// Note: Token metadata is stable and persists for TTL duration
+		clearBalanceCache();
 		
 		const ws = this.ctx?.getWebSocket?.();
 		if (ws?.cleanup) {
@@ -1692,8 +1693,9 @@ class App {
 		}
 		this.lastDisconnectNotification = now;
 
-		// Clear token caches on wallet disconnect (issue #174)
-		clearTokenCaches();
+		// Clear balance cache on wallet disconnect (issue #174)
+		// Note: Token metadata is stable and persists for TTL duration
+		clearBalanceCache();
 
 		const walletConnectBtn = document.getElementById('walletConnect');
 		const walletInfo = document.getElementById('walletInfo');

--- a/js/app.js
+++ b/js/app.js
@@ -33,6 +33,7 @@ import { createAppContext, setGlobalContext } from './services/AppContext.js';
 import { hasAnyClaimables } from './utils/claims.js';
 import { isUserRejection } from './utils/ui.js';
 import { escapeHtml } from './utils/html.js';
+import { clearTokenCaches } from './utils/contractTokens.js';
 
 const BOOTSTRAP_LOADER_STATE_KEY = 'whaleswapBootstrapLoader';
 class App {
@@ -930,6 +931,9 @@ class App {
 	}
 
 	async recreateNetworkServices() {
+		// Clear token caches on network switch (issue #174)
+		clearTokenCaches();
+		
 		const ws = this.ctx?.getWebSocket?.();
 		if (ws?.cleanup) {
 			try {
@@ -1687,6 +1691,9 @@ class App {
 			return;
 		}
 		this.lastDisconnectNotification = now;
+
+		// Clear token caches on wallet disconnect (issue #174)
+		clearTokenCaches();
 
 		const walletConnectBtn = document.getElementById('walletConnect');
 		const walletInfo = document.getElementById('walletInfo');

--- a/js/components/CreateOrder.js
+++ b/js/components/CreateOrder.js
@@ -4,7 +4,7 @@ import { getNetworkConfig } from '../config/networks.js';
 import { walletManager } from '../services/WalletManager.js';
 import { setVisibility } from '../utils/ui.js';
 import { erc20Abi } from '../abi/erc20.js';
-import { getAllWalletTokens, getContractAllowedTokens, clearTokenCaches, getTokenBalanceInfo } from '../utils/contractTokens.js';
+import { getAllWalletTokens, getContractAllowedTokens, clearBalanceCache, getTokenBalanceInfo } from '../utils/contractTokens.js';
 import { contractService } from '../services/ContractService.js';
 import { createLogger } from '../services/LogService.js';
 import { validateSellBalance } from '../utils/balanceValidation.js';
@@ -1991,10 +1991,12 @@ export class CreateOrder extends BaseComponent {
                 this.debug('Transaction confirmed successfully:', receipt);
 
                 try {
-                    clearTokenCaches();
+                    // Only clear balance cache - metadata is stable and should persist
+                    // (per issue #174 - token metadata should survive order creation)
+                    clearBalanceCache();
                     this.refreshOpenTokenModals();
                 } catch (refreshError) {
-                    this.debug('Post-order cache clear/refresh failed:', refreshError);
+                    this.debug('Post-order balance cache clear/refresh failed:', refreshError);
                 }
 
                 const ws = this.ctx.getWebSocket();

--- a/js/services/TokenMetadataCache.js
+++ b/js/services/TokenMetadataCache.js
@@ -196,16 +196,23 @@ class TokenMetadataCache {
      * Set token metadata in cache
      * @param {string} tokenAddress 
      * @param {Object} metadata - {symbol, name, decimals, iconUrl?, displaySymbol?}
+     * @param {number} [chainId] - Optional chain ID (defaults to current network)
      */
-    set(tokenAddress, metadata) {
-        const cache = this._getCacheForCurrentNetwork();
-        const chainId = this._currentChainId;
+    set(tokenAddress, metadata, chainId) {
+        const targetChainId = chainId || this._currentChainId;
+        
+        // Get or create cache for the target chain
+        if (!this._caches.has(targetChainId)) {
+            this._caches.set(targetChainId, new Map());
+        }
+        const cache = this._caches.get(targetChainId);
+        
         const normalizedAddress = tokenAddress.toLowerCase();
         
         cache.set(normalizedAddress, { value: metadata, ts: Date.now() });
-        this._persistToStorage(chainId);
+        this._persistToStorage(targetChainId);
         
-        debug(`Cached metadata for ${normalizedAddress}:`, metadata);
+        debug(`Cached metadata for ${normalizedAddress} on chain ${targetChainId}:`, metadata);
     }
 
     /**
@@ -251,6 +258,9 @@ class TokenMetadataCache {
      */
     async fetch(tokenAddress, options = {}) {
         const normalizedAddress = tokenAddress.toLowerCase();
+        
+        // Capture the originating chain ID at the start to prevent race conditions
+        const originatingChainId = this._getCurrentChainId();
         
         // Check cache first (unless skipCache is true)
         if (!options.skipCache) {
@@ -315,8 +325,8 @@ class TokenMetadataCache {
                 iconUrl
             };
 
-            // Cache the result
-            this.set(normalizedAddress, metadata);
+            // Cache the result in the originating chain's cache (prevents race condition)
+            this.set(normalizedAddress, metadata, originatingChainId);
             
             return metadata;
 

--- a/js/services/TokenMetadataCache.js
+++ b/js/services/TokenMetadataCache.js
@@ -1,0 +1,445 @@
+/**
+ * TokenMetadataCache - Single canonical source for token metadata
+ * 
+ * This service provides a unified, network-scoped cache for stable token metadata:
+ * - symbol, name, decimals, iconUrl, displaySymbol
+ * 
+ * Lifetime:
+ * - Persists for the current page session
+ * - NOT cleared on tab switch or order creation
+ * - Cleared on network switch
+ * - Cleared on wallet disconnect (full app reset)
+ * 
+ * Balance data is NOT part of this cache - balances are user-specific and
+ * should be invalidated separately.
+ */
+
+import { ethers } from 'ethers';
+import { getNetworkConfig } from '../config/networks.js';
+import { contractService } from './ContractService.js';
+import { createLogger } from './LogService.js';
+import { tokenIconService } from './TokenIconService.js';
+import { tryAggregate as multicallTryAggregate } from './MulticallService.js';
+import { erc20Abi } from '../abi/erc20.js';
+
+const ERC20_INTERFACE = new ethers.utils.Interface(erc20Abi);
+
+const logger = createLogger('TOKEN_METADATA_CACHE');
+const debug = logger.debug.bind(logger);
+const warn = logger.warn.bind(logger);
+const error = logger.error.bind(logger);
+
+// Storage configuration
+const STORAGE_KEY_PREFIX = 'tokenMetadataCache';
+const STORAGE_SCHEMA = 'v2'; // Bumped for unified cache
+const CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days for stable metadata
+
+/**
+ * TokenMetadataCache class
+ * Manages a single canonical cache per network
+ */
+class TokenMetadataCache {
+    constructor() {
+        // Map<chainId, Map<address, {value, ts}>>
+        this._caches = new Map();
+        this._currentChainId = null;
+        this._storageLoadedForChains = new Set();
+    }
+
+    /**
+     * Get the current chain ID from network config
+     * @returns {number} Chain ID
+     */
+    _getCurrentChainId() {
+        try {
+            const network = getNetworkConfig();
+            return parseInt(network.chainId, 16) || 137;
+        } catch (_) {
+            return 137; // Default to Polygon
+        }
+    }
+
+    /**
+     * Get the storage key for a specific chain
+     * @param {number} chainId 
+     * @returns {string}
+     */
+    _getStorageKey(chainId) {
+        return `${STORAGE_KEY_PREFIX}:${STORAGE_SCHEMA}:${chainId}`;
+    }
+
+    /**
+     * Get or create the cache for the current network
+     * @returns {Map}
+     */
+    _getCacheForCurrentNetwork() {
+        const chainId = this._getCurrentChainId();
+        
+        // Detect network switch and clear old cache from memory
+        if (this._currentChainId !== null && this._currentChainId !== chainId) {
+            debug(`Network switch detected: ${this._currentChainId} -> ${chainId}`);
+            // Keep the old cache in _caches for potential switch back, but clear from active use
+        }
+        
+        this._currentChainId = chainId;
+        
+        if (!this._caches.has(chainId)) {
+            this._caches.set(chainId, new Map());
+        }
+        
+        return this._caches.get(chainId);
+    }
+
+    /**
+     * Load cache from localStorage for a specific chain
+     * @param {number} chainId 
+     */
+    _loadFromStorage(chainId) {
+        if (this._storageLoadedForChains.has(chainId)) {
+            return;
+        }
+        
+        this._storageLoadedForChains.add(chainId);
+        
+        if (typeof localStorage === 'undefined') {
+            return;
+        }
+
+        try {
+            const raw = localStorage.getItem(this._getStorageKey(chainId));
+            if (!raw) {
+                return;
+            }
+
+            const parsed = JSON.parse(raw);
+            const now = Date.now();
+            const cache = this._caches.get(chainId) || new Map();
+
+            Object.entries(parsed).forEach(([address, entry]) => {
+                if (!entry || typeof entry !== 'object') {
+                    return;
+                }
+                if (typeof entry.ts !== 'number' || !entry.value) {
+                    return;
+                }
+                if ((now - entry.ts) >= CACHE_TTL_MS) {
+                    return;
+                }
+                cache.set(address.toLowerCase(), { value: entry.value, ts: entry.ts });
+            });
+
+            this._caches.set(chainId, cache);
+            debug(`Loaded ${cache.size} cached tokens from storage for chain ${chainId}`);
+        } catch (err) {
+            debug(`Failed to load token metadata cache from storage for chain ${chainId}:`, err);
+        }
+    }
+
+    /**
+     * Persist cache to localStorage for a specific chain
+     * @param {number} chainId 
+     */
+    _persistToStorage(chainId) {
+        if (typeof localStorage === 'undefined') {
+            return;
+        }
+
+        try {
+            const cache = this._caches.get(chainId);
+            if (!cache) {
+                return;
+            }
+
+            const now = Date.now();
+            const serializable = {};
+
+            cache.forEach((entry, address) => {
+                if (!entry || typeof entry.ts !== 'number' || !entry.value) {
+                    return;
+                }
+                if ((now - entry.ts) >= CACHE_TTL_MS) {
+                    return;
+                }
+                serializable[address] = entry;
+            });
+
+            localStorage.setItem(this._getStorageKey(chainId), JSON.stringify(serializable));
+        } catch (err) {
+            debug(`Failed to persist token metadata cache to storage for chain ${chainId}:`, err);
+        }
+    }
+
+    /**
+     * Get token metadata from cache
+     * @param {string} tokenAddress 
+     * @returns {Object|null} Token metadata or null if not cached
+     */
+    get(tokenAddress) {
+        const cache = this._getCacheForCurrentNetwork();
+        const chainId = this._currentChainId;
+        
+        // Ensure storage is loaded
+        this._loadFromStorage(chainId);
+        
+        const normalizedAddress = tokenAddress.toLowerCase();
+        const cached = cache.get(normalizedAddress);
+        
+        if (cached && (Date.now() - cached.ts) < CACHE_TTL_MS) {
+            debug(`Cache hit for ${normalizedAddress}`);
+            return cached.value;
+        }
+        
+        return null;
+    }
+
+    /**
+     * Set token metadata in cache
+     * @param {string} tokenAddress 
+     * @param {Object} metadata - {symbol, name, decimals, iconUrl?, displaySymbol?}
+     */
+    set(tokenAddress, metadata) {
+        const cache = this._getCacheForCurrentNetwork();
+        const chainId = this._currentChainId;
+        const normalizedAddress = tokenAddress.toLowerCase();
+        
+        cache.set(normalizedAddress, { value: metadata, ts: Date.now() });
+        this._persistToStorage(chainId);
+        
+        debug(`Cached metadata for ${normalizedAddress}:`, metadata);
+    }
+
+    /**
+     * Check if token is in cache
+     * @param {string} tokenAddress 
+     * @returns {boolean}
+     */
+    has(tokenAddress) {
+        return this.get(tokenAddress) !== null;
+    }
+
+    /**
+     * Get all cached tokens for current network
+     * @returns {Array<Object>} Array of token metadata objects
+     */
+    getAll() {
+        const cache = this._getCacheForCurrentNetwork();
+        const chainId = this._currentChainId;
+        
+        // Ensure storage is loaded
+        this._loadFromStorage(chainId);
+        
+        const now = Date.now();
+        const tokens = [];
+        
+        cache.forEach((entry, address) => {
+            if (entry && entry.value && (now - entry.ts) < CACHE_TTL_MS) {
+                tokens.push({
+                    address,
+                    ...entry.value
+                });
+            }
+        });
+        
+        return tokens;
+    }
+
+    /**
+     * Fetch token metadata from chain (with caching)
+     * @param {string} tokenAddress 
+     * @param {Object} options - {provider?, skipCache?: boolean}
+     * @returns {Promise<Object>} Token metadata
+     */
+    async fetch(tokenAddress, options = {}) {
+        const normalizedAddress = tokenAddress.toLowerCase();
+        
+        // Check cache first (unless skipCache is true)
+        if (!options.skipCache) {
+            const cached = this.get(normalizedAddress);
+            if (cached) {
+                return cached;
+            }
+        }
+        
+        try {
+            const provider = options.provider || contractService.getProvider();
+            if (!provider) {
+                throw new Error('Provider not available');
+            }
+
+            // Use multicall for efficiency
+            const calls = [
+                { target: tokenAddress, callData: ERC20_INTERFACE.encodeFunctionData('symbol', []) },
+                { target: tokenAddress, callData: ERC20_INTERFACE.encodeFunctionData('name', []) },
+                { target: tokenAddress, callData: ERC20_INTERFACE.encodeFunctionData('decimals', []) }
+            ];
+
+            let symbol, name, decimals;
+            const mcResult = await multicallTryAggregate(calls);
+            
+            if (mcResult) {
+                try {
+                    symbol = ERC20_INTERFACE.decodeFunctionResult('symbol', mcResult[0].returnData)[0];
+                    name = ERC20_INTERFACE.decodeFunctionResult('name', mcResult[1].returnData)[0];
+                    decimals = ERC20_INTERFACE.decodeFunctionResult('decimals', mcResult[2].returnData)[0];
+                } catch (_) {
+                    // Fallback to direct calls
+                    const tokenContract = new ethers.Contract(tokenAddress, erc20Abi, provider);
+                    [symbol, name, decimals] = await Promise.all([
+                        tokenContract.symbol(),
+                        tokenContract.name(),
+                        tokenContract.decimals()
+                    ]);
+                }
+            } else {
+                const tokenContract = new ethers.Contract(tokenAddress, erc20Abi, provider);
+                [symbol, name, decimals] = await Promise.all([
+                    tokenContract.symbol(),
+                    tokenContract.name(),
+                    tokenContract.decimals()
+                ]);
+            }
+
+            // Get icon URL
+            let iconUrl = null;
+            try {
+                const chainId = this._getCurrentChainId();
+                iconUrl = await tokenIconService.getIconUrl(tokenAddress, chainId);
+            } catch (err) {
+                debug(`Failed to get icon for token ${tokenAddress}:`, err);
+            }
+
+            const metadata = {
+                symbol,
+                name,
+                decimals: parseInt(decimals),
+                iconUrl
+            };
+
+            // Cache the result
+            this.set(normalizedAddress, metadata);
+            
+            return metadata;
+
+        } catch (err) {
+            error(`Failed to fetch metadata for token ${tokenAddress}:`, err);
+            
+            // Return fallback without caching (per issue #173 - don't poison cache with fallbacks)
+            return {
+                address: normalizedAddress,
+                symbol: `${tokenAddress.slice(0, 4)}...${tokenAddress.slice(-4)}`,
+                decimals: 18,
+                name: 'Unknown Token',
+                iconUrl: null,
+                _isFallback: true
+            };
+        }
+    }
+
+    /**
+     * Batch fetch metadata for multiple tokens
+     * @param {string[]} tokenAddresses 
+     * @param {Object} options 
+     * @returns {Promise<Map<string, Object>>} Map of address -> metadata
+     */
+    async fetchBatch(tokenAddresses, options = {}) {
+        const results = new Map();
+        
+        if (!tokenAddresses || tokenAddresses.length === 0) {
+            return results;
+        }
+
+        // Separate cached from uncached
+        const uncached = [];
+        for (const address of tokenAddresses) {
+            const cached = this.get(address);
+            if (cached && !options.skipCache) {
+                results.set(address.toLowerCase(), cached);
+            } else {
+                uncached.push(address);
+            }
+        }
+
+        if (uncached.length === 0) {
+            return results;
+        }
+
+        // Fetch uncached tokens
+        // Note: Could optimize with batch multicall in the future
+        for (const address of uncached) {
+            try {
+                const metadata = await this.fetch(address, options);
+                results.set(address.toLowerCase(), metadata);
+            } catch (err) {
+                warn(`Failed to fetch metadata for ${address}:`, err);
+            }
+        }
+
+        return results;
+    }
+
+    /**
+     * Clear cache for current network
+     */
+    clearCurrentNetwork() {
+        const chainId = this._getCurrentChainId();
+        const cache = this._caches.get(chainId);
+        
+        if (cache) {
+            cache.clear();
+        }
+        
+        // Clear from storage
+        if (typeof localStorage !== 'undefined') {
+            localStorage.removeItem(this._getStorageKey(chainId));
+        }
+        
+        debug(`Cleared token metadata cache for chain ${chainId}`);
+    }
+
+    /**
+     * Clear all caches (for wallet disconnect / full reset)
+     */
+    clearAll() {
+        this._caches.clear();
+        this._storageLoadedForChains.clear();
+        this._currentChainId = null;
+        
+        // Clear all from storage
+        if (typeof localStorage !== 'undefined') {
+            // Find and remove all keys matching our prefix
+            const keysToRemove = [];
+            for (let i = 0; i < localStorage.length; i++) {
+                const key = localStorage.key(i);
+                if (key && key.startsWith(STORAGE_KEY_PREFIX)) {
+                    keysToRemove.push(key);
+                }
+            }
+            keysToRemove.forEach(key => localStorage.removeItem(key));
+        }
+        
+        debug('Cleared all token metadata caches');
+    }
+
+    /**
+     * Get cache statistics for debugging
+     * @returns {Object}
+     */
+    getStats() {
+        const chainId = this._getCurrentChainId();
+        const cache = this._caches.get(chainId);
+        
+        return {
+            currentChainId: chainId,
+            cachedTokensCount: cache ? cache.size : 0,
+            loadedChains: Array.from(this._storageLoadedForChains)
+        };
+    }
+}
+
+// Singleton instance
+export const tokenMetadataCache = new TokenMetadataCache();
+
+// Also export class for testing
+export { TokenMetadataCache };
+
+export default tokenMetadataCache;

--- a/js/services/TokenMetadataCache.js
+++ b/js/services/TokenMetadataCache.js
@@ -186,7 +186,8 @@ class TokenMetadataCache {
         
         if (cached && (Date.now() - cached.ts) < CACHE_TTL_MS) {
             debug(`Cache hit for ${normalizedAddress}`);
-            return cached.value;
+            // Reattach address to preserve caller contract (per PR #177 review)
+            return { ...cached.value, address: normalizedAddress };
         }
         
         return null;
@@ -328,7 +329,8 @@ class TokenMetadataCache {
             // Cache the result in the originating chain's cache (prevents race condition)
             this.set(normalizedAddress, metadata, originatingChainId);
             
-            return metadata;
+            // Return with address attached (per PR #177 review - preserve caller contract)
+            return { ...metadata, address: normalizedAddress };
 
         } catch (err) {
             error(`Failed to fetch metadata for token ${tokenAddress}:`, err);

--- a/js/services/WebSocket.js
+++ b/js/services/WebSocket.js
@@ -6,6 +6,7 @@ import { contractService } from './ContractService.js';
 import { erc20Abi } from '../abi/erc20.js';
 import { createLogger } from './LogService.js';
 import { tokenIconService } from './TokenIconService.js';
+import { tokenMetadataCache } from './TokenMetadataCache.js';
 
 export class WebSocketService {
     constructor(options = {}) {
@@ -74,8 +75,29 @@ export class WebSocketService {
         this.error = logger.error.bind(logger);
         this.warn = logger.warn.bind(logger);
         
-        this.tokenCache = new Map();  // Add token cache
+        // Token metadata is now managed by the shared tokenMetadataCache service
+        // this.tokenCache is deprecated - use tokenMetadataCache instead
         this.pricingUpdateHandler = null;
+    }
+
+    /**
+     * Get the token cache (delegates to shared tokenMetadataCache)
+     * @deprecated Use tokenMetadataCache directly
+     */
+    get tokenCache() {
+        // Return a Map-like interface backed by the shared cache
+        return {
+            has: (address) => tokenMetadataCache.has(address),
+            get: (address) => tokenMetadataCache.get(address),
+            set: (address, metadata) => tokenMetadataCache.set(address, metadata),
+            values: () => tokenMetadataCache.getAll().values(),
+            entries: () => {
+                const tokens = tokenMetadataCache.getAll();
+                return tokens.map(t => [t.address, t]).values();
+            },
+            clear: () => tokenMetadataCache.clearCurrentNetwork(),
+            size: tokenMetadataCache.getAll().length
+        };
     }
 
     clearReconnectTimer() {
@@ -1611,10 +1633,11 @@ export class WebSocketService {
             // Normalize address to lowercase for consistent comparison
             const normalizedAddress = tokenAddress.toLowerCase();
 
-            // 1. First check cache
-            if (this.tokenCache.has(normalizedAddress)) {
-                this.debug('Token info found in cache:', normalizedAddress);
-                return this.tokenCache.get(normalizedAddress);
+            // 1. First check shared cache
+            const cached = tokenMetadataCache.get(normalizedAddress);
+            if (cached) {
+                this.debug('Token info found in shared cache:', normalizedAddress);
+                return cached;
             }
 
             // 2. Fetch from contract using queueRequest
@@ -1649,9 +1672,9 @@ export class WebSocketService {
                     iconUrl: iconUrl
                 };
 
-                // Cache the result
-                this.tokenCache.set(normalizedAddress, tokenInfo);
-                this.debug('Added token to cache:', tokenInfo);
+                // Cache the result in shared cache
+                tokenMetadataCache.set(normalizedAddress, tokenInfo);
+                this.debug('Added token to shared cache:', tokenInfo);
 
                 return tokenInfo;
             };
@@ -1664,12 +1687,13 @@ export class WebSocketService {
 
         } catch (error) {
             this.debug('Error getting token info:', error);
-            // Return a basic fallback object
+            // Return a basic fallback object (not cached - per issue #173)
             const fallback = {
                 address: tokenAddress.toLowerCase(),
                 symbol: `${tokenAddress.slice(0, 4)}...${tokenAddress.slice(-4)}`,
                 decimals: 18,
-                name: 'Unknown Token'
+                name: 'Unknown Token',
+                _isFallback: true
             };
             return fallback;
         }

--- a/js/utils/contractTokens.js
+++ b/js/utils/contractTokens.js
@@ -4,6 +4,7 @@ import { contractService } from '../services/ContractService.js';
 import { createLogger } from '../services/LogService.js';
 import { tokenIconService } from '../services/TokenIconService.js';
 import { tryAggregate as multicallTryAggregate } from '../services/MulticallService.js';
+import { tokenMetadataCache } from '../services/TokenMetadataCache.js';
 import { erc20Abi } from '../abi/erc20.js';
 
 const ERC20_INTERFACE = new ethers.utils.Interface(erc20Abi);
@@ -17,91 +18,13 @@ const warn = logger.warn.bind(logger);
 // Concurrency control
 const CONCURRENCY_LIMIT = 5; // Max concurrent metadata/icon tasks
 
-// No global rate limiting state needed with multicall + caching
-
-// Simple in-memory caches
-const TOKEN_METADATA_CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+// Balance cache is kept separate from metadata cache (per issue #174)
+// Balances are user-specific and should be invalidated on create/fill/cancel
 const BALANCE_CACHE_TTL_MS = 30 * 1000; // 30 seconds
-const tokenMetadataCache = new Map(); // key: tokenAddress (lowercase) -> { value, ts }
 const balanceCache = new Map(); // key: `${token}-${user}` -> { value, ts }
-const TOKEN_METADATA_STORAGE_KEY_PREFIX = 'tokenMetadataCache';
-const TOKEN_METADATA_STORAGE_SCHEMA = 'v1';
-let tokenMetadataStorageLoaded = false;
 
-function getTokenMetadataStorageKey() {
-    try {
-        const network = getNetworkConfig();
-        const chainId = parseInt(network.chainId, 16);
-        const chainSegment = Number.isFinite(chainId) ? String(chainId) : 'unknown';
-        return `${TOKEN_METADATA_STORAGE_KEY_PREFIX}:${TOKEN_METADATA_STORAGE_SCHEMA}:${chainSegment}`;
-    } catch (_) {
-        return `${TOKEN_METADATA_STORAGE_KEY_PREFIX}:${TOKEN_METADATA_STORAGE_SCHEMA}:unknown`;
-    }
-}
-
-function loadTokenMetadataCacheFromStorage() {
-    if (tokenMetadataStorageLoaded || typeof localStorage === 'undefined') {
-        return;
-    }
-
-    tokenMetadataStorageLoaded = true;
-
-    try {
-        const raw = localStorage.getItem(getTokenMetadataStorageKey());
-        if (!raw) {
-            return;
-        }
-
-        const parsed = JSON.parse(raw);
-        const now = Date.now();
-
-        Object.entries(parsed).forEach(([address, entry]) => {
-            if (!entry || typeof entry !== 'object') {
-                return;
-            }
-            if (typeof entry.ts !== 'number' || !entry.value) {
-                return;
-            }
-            if ((now - entry.ts) >= TOKEN_METADATA_CACHE_TTL_MS) {
-                return;
-            }
-            tokenMetadataCache.set(address, { value: entry.value, ts: entry.ts });
-        });
-    } catch (err) {
-        debug('Failed to load token metadata cache from localStorage:', err);
-    }
-}
-
-function persistTokenMetadataCacheToStorage() {
-    if (typeof localStorage === 'undefined') {
-        return;
-    }
-
-    try {
-        const now = Date.now();
-        const serializable = {};
-
-        tokenMetadataCache.forEach((entry, address) => {
-            if (!entry || typeof entry.ts !== 'number' || !entry.value) {
-                return;
-            }
-            if ((now - entry.ts) >= TOKEN_METADATA_CACHE_TTL_MS) {
-                return;
-            }
-            serializable[address] = entry;
-        });
-
-        localStorage.setItem(getTokenMetadataStorageKey(), JSON.stringify(serializable));
-    } catch (err) {
-        debug('Failed to persist token metadata cache to localStorage:', err);
-    }
-}
-
-function setTokenMetadataCache(address, metadata) {
-    const addressKey = address.toLowerCase();
-    tokenMetadataCache.set(addressKey, { value: metadata, ts: Date.now() });
-    persistTokenMetadataCacheToStorage();
-}
+// Note: Token metadata cache is now managed by TokenMetadataCache service
+// This provides a unified cache shared across WebSocketService, CreateOrder, and order views
 
 /**
  * Batch fetch balances and decimals for many tokens using multicall
@@ -258,91 +181,13 @@ export async function getContractAllowedTokens(options = {}) {
 }
 
 /**
- * Get token metadata (symbol, name, decimals)
+ * Get token metadata (symbol, name, decimals) - uses shared TokenMetadataCache
  * @param {string} tokenAddress - The token address
  * @returns {Promise<Object>} Token metadata
  */
 async function getTokenMetadata(tokenAddress) {
-    try {
-        const normalizedAddress = tokenAddress.toLowerCase();
-
-        loadTokenMetadataCacheFromStorage();
-
-        const cached = tokenMetadataCache.get(normalizedAddress);
-        if (cached && (Date.now() - cached.ts) < TOKEN_METADATA_CACHE_TTL_MS) {
-            return cached.value;
-        }
-
-        const provider = contractService.getProvider();
-
-        // Prepare multicall for symbol, name, decimals (single ABI source: erc20.js)
-        const calls = [
-            { target: tokenAddress, callData: ERC20_INTERFACE.encodeFunctionData('symbol', []) },
-            { target: tokenAddress, callData: ERC20_INTERFACE.encodeFunctionData('name', []) },
-            { target: tokenAddress, callData: ERC20_INTERFACE.encodeFunctionData('decimals', []) }
-        ];
-
-        let symbol, name, decimals;
-        const mcResult = await multicallTryAggregate(calls);
-        if (mcResult) {
-            // Decode gracefully; if any fail, fallback to direct
-            try {
-                symbol = ERC20_INTERFACE.decodeFunctionResult('symbol', mcResult[0].returnData)[0];
-                name = ERC20_INTERFACE.decodeFunctionResult('name', mcResult[1].returnData)[0];
-                decimals = ERC20_INTERFACE.decodeFunctionResult('decimals', mcResult[2].returnData)[0];
-            } catch (_) {
-                const tokenContract = new ethers.Contract(tokenAddress, erc20Abi, provider);
-                [symbol, name, decimals] = await Promise.all([
-                    tokenContract.symbol(),
-                    tokenContract.name(),
-                    tokenContract.decimals()
-                ]);
-            }
-        } else {
-            const tokenContract = new ethers.Contract(tokenAddress, erc20Abi, provider);
-            [symbol, name, decimals] = await Promise.all([
-                tokenContract.symbol(),
-                tokenContract.name(),
-                tokenContract.decimals()
-            ]);
-        }
-
-        const metadata = {
-            symbol,
-            name,
-            decimals: parseInt(decimals)
-        };
-
-        setTokenMetadataCache(normalizedAddress, metadata);
-        return metadata;
-
-    } catch (err) {
-        // Check if it's a rate limit error
-        if (err.code === -32005 || err.message?.includes('rate limit')) {
-            warn(`Rate limit hit while getting metadata for token ${tokenAddress}, using fallback`);
-            
-            // Return fallback metadata for rate-limited requests
-            const fallbackMetadata = {
-                symbol: 'UNKNOWN',
-                name: 'Unknown Token',
-                decimals: 18
-            };
-            
-            setTokenMetadataCache(tokenAddress, fallbackMetadata);
-            return fallbackMetadata;
-        }
-        
-        error(`Failed to get metadata for token ${tokenAddress}:`, err);
-        
-        // Return fallback metadata
-        const fallbackMetadata = {
-            symbol: 'UNKNOWN',
-            name: 'Unknown Token',
-            decimals: 18
-        };
-        setTokenMetadataCache(tokenAddress, fallbackMetadata);
-        return fallbackMetadata;
-    }
+    // Delegate to shared cache
+    return tokenMetadataCache.fetch(tokenAddress);
 }
 
 /**
@@ -460,18 +305,34 @@ export async function getTokenBalanceInfo(tokenAddress) {
 }
 
 /**
- * Clear all caches (useful for testing or when switching networks)
+ * Clear balance cache only (balances are user-specific and should be invalidated on create/fill/cancel)
+ */
+export function clearBalanceCache() {
+    balanceCache.clear();
+    debug('Balance cache cleared');
+}
+
+/**
+ * Clear all caches (metadata + balance) - use for network switch or full reset
+ * Note: Token metadata cache is now managed by TokenMetadataCache service
  */
 export function clearTokenCaches() {
-    tokenMetadataCache.clear();
+    // Clear balance cache (local)
     balanceCache.clear();
-    tokenMetadataStorageLoaded = false;
+    
+    // Clear shared metadata cache for current network
+    tokenMetadataCache.clearCurrentNetwork();
 
-    if (typeof localStorage !== 'undefined') {
-        localStorage.removeItem(getTokenMetadataStorageKey());
-    }
+    debug('Token caches cleared (metadata + balance)');
+}
 
-    debug('Token caches cleared');
+/**
+ * Clear all caches for all networks - use for wallet disconnect / full app reset
+ */
+export function clearAllTokenCaches() {
+    balanceCache.clear();
+    tokenMetadataCache.clearAll();
+    debug('All token caches cleared (all networks)');
 }
 
 // Removed deprecated resetRateLimiting() - no longer needed with multicall + caching


### PR DESCRIPTION
- Create TokenMetadataCache singleton service with network-scoped caching
- Update WebSocketService to delegate to shared cache
- Update contractTokens.js to use shared cache with new exports
- CreateOrder now only clears balance cache after order creation (not metadata)
- Clear token caches on network switch and wallet disconnect in app.js

Key changes:
- One canonical token metadata cache per active network
- Token metadata persists across tab switches and order activity
- Balance cache cleared separately from metadata cache
- Fallback metadata NOT cached (issue #173 compliance)