### PR TITLE
Fix #153: Make header/network selector reflect wallet connection only

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -865,6 +865,7 @@ class App {
 		if (missingNetwork && restoredNetwork?.slug === targetNetwork?.slug) {
 			setNetworkSetupRequired(targetNetwork.slug);
 			syncNetworkBadgeFromState();
+			syncAddNetworkButtonVisibility();
 		}
 		if (restoredNetwork) {
 			this.showWarning(this.getNetworkSwitchFailureWarning(error, targetNetwork, restoredNetwork));
@@ -874,11 +875,13 @@ class App {
 		if (missingNetwork) {
 			setNetworkSetupRequired(targetNetwork.slug);
 			syncNetworkBadgeFromState();
+			syncAddNetworkButtonVisibility();
 			this.showWarning(this.getNetworkSwitchFailureWarning(error, targetNetwork));
 			return;
 		}
 		clearNetworkSetupRequired();
 		syncNetworkBadgeFromState();
+		syncAddNetworkButtonVisibility();
 		this.showWarning(this.getNetworkSwitchFailureWarning(error, targetNetwork));
 	}
 
@@ -1139,29 +1142,11 @@ class App {
 			return;
 		}
 
-		const wallet = this.ctx?.getWallet?.();
-		const isConnected = !!wallet?.isWalletConnected?.() && !!wallet?.getSigner?.();
-		if (!isConnected) {
-			triggerPageReloadWithSwitchFallback({
-				loaderMode: 'spinner',
-				loaderMessage: `Switching to ${getNetworkLabel(network)}...`
-			});
-			return;
-		}
-
-		const walletNetwork = getNetworkById(this.ctx.getWalletChainId() || walletManager.chainId || null);
-		if (walletNetwork?.slug === network.slug) {
-			await this.handleSuccessfulConnectedNetworkTransition(network, {
-				source: 'network-selector',
-				selectedChainChanged,
-			});
-			return;
-		}
-
-		await this.switchWalletToNetwork(network, {
-			source: 'network-selector',
-			selectedChainChanged,
-			previousSelectedNetwork,
+		// Issue #153: Network selection only updates app state, does not trigger wallet operations
+		// The dropdown is an app network selector, not a wallet network switcher
+		triggerPageReloadWithSwitchFallback({
+			loaderMode: 'spinner',
+			loaderMessage: `Switching to ${getNetworkLabel(network)}...`
 		});
 	}
 
@@ -2148,12 +2133,20 @@ function triggerPageReloadWithSwitchFallback(options = {}) {
 		console.warn('[App] Reload failed after network switch:', error);
 	}
 }
+
+/**
+ * Sync network badge from app state (issue #153)
+ * The network badge shows the selected app network only.
+ * Wallet connection status is handled by the wallet button, not the network selector.
+ */
 function syncNetworkBadgeFromState() {
 	if (!networkBadge) return;
 
 	const selectedSlug = selectedNetworkSlug || window.app?.ctx?.getSelectedChainSlug?.() || getDefaultNetwork().slug;
 	const selectedNetwork = getNetworkBySlug(selectedSlug) || getDefaultNetwork();
 	renderNetworkBadge(selectedNetwork);
+
+	// Network badge only shows selected network, not wallet connection status
 	networkBadge.classList.remove('connected', 'setup-needed', 'wrong-network', 'disconnected');
 	if (networkButton) {
 		networkButton.dataset.networkStatus = 'default';
@@ -2162,48 +2155,10 @@ function syncNetworkBadgeFromState() {
 		networkDropdown.dataset.networkStatus = 'default';
 	}
 
-	const walletChainId = window.app?.ctx?.getWalletChainId?.();
-	if (!walletChainId) {
-		networkBadge.classList.add('disconnected');
-		if (networkButton) {
-			networkButton.dataset.networkStatus = 'disconnected';
-		}
-		if (networkDropdown) {
-			networkDropdown.dataset.networkStatus = 'disconnected';
-		}
-		syncAddNetworkButtonVisibility();
-		return;
+	// Hide add network button - network selection no longer triggers wallet operations
+	if (addNetworkButton) {
+		addNetworkButton.classList.add('hidden');
 	}
-
-	const walletNetwork = getNetworkById(walletChainId);
-	if (walletNetwork && walletNetwork.slug === selectedNetwork.slug) {
-		clearNetworkSetupRequired();
-		networkBadge.classList.add('connected');
-		if (networkButton) {
-			networkButton.dataset.networkStatus = 'connected';
-		}
-		if (networkDropdown) {
-			networkDropdown.dataset.networkStatus = 'connected';
-		}
-	} else if (networkSetupRequiredSlug && networkSetupRequiredSlug === selectedNetwork.slug) {
-		networkBadge.classList.add('setup-needed');
-		if (networkButton) {
-			networkButton.dataset.networkStatus = 'setup-needed';
-		}
-		if (networkDropdown) {
-			networkDropdown.dataset.networkStatus = 'setup-needed';
-		}
-	} else {
-		networkBadge.classList.add('wrong-network');
-		if (networkButton) {
-			networkButton.dataset.networkStatus = 'wrong-network';
-		}
-		if (networkDropdown) {
-			networkDropdown.dataset.networkStatus = 'wrong-network';
-		}
-	}
-
-	syncAddNetworkButtonVisibility();
 }
 
 function applySelectedNetwork(network, { updateUrl = true } = {}) {

--- a/js/app.js
+++ b/js/app.js
@@ -35,6 +35,7 @@ import { isUserRejection } from './utils/ui.js';
 import { escapeHtml } from './utils/html.js';
 
 const BOOTSTRAP_LOADER_STATE_KEY = 'whaleswapBootstrapLoader';
+const ACTIVE_TAB_STATE_KEY = 'whaleswapActiveTab';
 class App {
 	constructor() {
 		this.isInitializing = false;
@@ -694,7 +695,8 @@ class App {
 					[BOOTSTRAP_LOADER_STATE_KEY]: {
 						mode: mode === 'spinner' ? 'spinner' : 'skeleton',
 						message: String(message || '')
-					}
+					},
+					[ACTIVE_TAB_STATE_KEY]: this.currentTab || 'view-orders'
 				},
 				'',
 				window.location.href
@@ -1142,12 +1144,24 @@ class App {
 			return;
 		}
 
-		// Issue #153: Network selection only updates app state, does not trigger wallet operations
-		// The dropdown is an app network selector, not a wallet network switcher
-		triggerPageReloadWithSwitchFallback({
-			loaderMode: 'spinner',
-			loaderMessage: `Switching to ${getNetworkLabel(network)}...`
-		});
+		// Issue #153: Network selection updates app state without triggering wallet operations
+		// For connected users, use in-app transition to preserve navigation context (PR #178 review)
+		const wallet = this.ctx?.getWallet?.();
+		const isConnected = !!wallet?.isWalletConnected?.() && !!wallet?.getSigner?.();
+		
+		if (isConnected) {
+			// Use in-app transition for connected users to preserve active tab
+			await this.handleSuccessfulConnectedNetworkTransition(network, {
+				source: 'network-selector',
+				selectedChainChanged,
+			});
+		} else {
+			// Use page reload for disconnected/read-only users
+			triggerPageReloadWithSwitchFallback({
+				loaderMode: 'spinner',
+				loaderMessage: `Switching to ${getNetworkLabel(network)}...`
+			});
+		}
 	}
 
 	async load () {
@@ -1283,7 +1297,12 @@ class App {
 				}
 			});
 
-			this.currentTab = hasInitialConnectedContext ? 'create-order' : 'view-orders';
+			// Restore active tab from history state if available (PR #178 review)
+			const historyState = window.history?.state || {};
+			const restoredTab = historyState[ACTIVE_TAB_STATE_KEY];
+			this.currentTab = (restoredTab && this.isTabVisible(restoredTab)) 
+				? restoredTab 
+				: (hasInitialConnectedContext ? 'create-order' : 'view-orders');
 
 				// Add wallet connection state handler
 				walletManager.addListener(async (event, data) => {
@@ -2155,10 +2174,9 @@ function syncNetworkBadgeFromState() {
 		networkDropdown.dataset.networkStatus = 'default';
 	}
 
-	// Hide add network button - network selection no longer triggers wallet operations
-	if (addNetworkButton) {
-		addNetworkButton.classList.add('hidden');
-	}
+	// Let syncAddNetworkButtonVisibility() decide visibility based on networkSetupRequiredSlug (PR #178 review)
+	// This preserves the "Add <Network>" retry affordance when setup is required
+	syncAddNetworkButtonVisibility();
 }
 
 function applySelectedNetwork(network, { updateUrl = true } = {}) {

--- a/js/app.js
+++ b/js/app.js
@@ -2086,7 +2086,9 @@ function getInitialSelectedNetwork() {
 function updateChainInUrl(slug) {
 	const url = new URL(window.location.href);
 	url.searchParams.set('chain', slug);
-	window.history.replaceState({}, '', url);
+	// Preserve existing history state (e.g., ACTIVE_TAB_STATE_KEY) when updating URL (PR #178 review)
+	const existingState = window.history?.state || {};
+	window.history.replaceState(existingState, '', url);
 }
 
 function markSelectedNetworkOption(slug) {

--- a/tests/app.headerWalletIndependence.test.js
+++ b/tests/app.headerWalletIndependence.test.js
@@ -1,0 +1,256 @@
+/**
+ * Regression tests for issue #153
+ * Phase 2: Make header/network selector reflect wallet connection only
+ * 
+ * Key behaviors:
+ * - Network badge shows selected app network only, not wallet connection status
+ * - Network dropdown selection does not trigger wallet switch/add-network
+ * - Selected-network changes still refresh app state/services correctly
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import '../js/app.js';
+import { getNetworkBySlug, getNetworkById } from '../js/config/networks.js';
+import { walletManager } from '../js/services/WalletManager.js';
+
+const BNB_CHAIN_ID = '0x38';
+const POLYGON_SLUG = 'polygon';
+const ETHEREUM_SLUG = 'ethereum';
+
+function setupNetworkSelectorDom() {
+	document.body.innerHTML = `
+		<button id="addNetworkButton" class="hidden">Add Network</button>
+		<div class="network-selector">
+			<button class="network-button" type="button">
+				<span class="network-badge"></span>
+			</button>
+			<div class="network-dropdown hidden"></div>
+		</div>
+	`;
+}
+
+function initializeApp({ walletChainId, selectedSlug }) {
+	setupNetworkSelectorDom();
+
+	const selectedNetwork = getNetworkBySlug(selectedSlug);
+	if (!selectedNetwork) {
+		throw new Error(`Unknown network slug: ${selectedSlug}`);
+	}
+
+	// Mock URL params
+	const originalLocation = window.location;
+	delete window.location;
+	window.location = {
+		...originalLocation,
+		href: `http://localhost:3000/?network=${selectedSlug}`,
+		search: `?network=${selectedSlug}`,
+		pathname: '/',
+		reload: vi.fn(),
+	};
+
+	// Initialize app context
+	const AppCtor = window.app.constructor;
+	const app = new AppCtor();
+	app.ctx = {
+		getSelectedChainSlug: () => selectedSlug,
+		getWalletChainId: () => walletChainId,
+		getWallet: () => ({
+			isWalletConnected: () => !!walletChainId,
+			getSigner: () => walletChainId ? {} : null,
+		}),
+	};
+	app.showWarning = vi.fn();
+	app.warn = vi.fn();
+	app.load = vi.fn(async () => {}); // Prevent full initialization
+	app.showGlobalLoader = vi.fn();
+	app.hideGlobalLoader = vi.fn();
+	window.app = app;
+
+	// Set selected network
+	window.selectedNetworkSlug = selectedSlug;
+
+	// Mock wallet manager
+	walletManager.chainId = walletChainId;
+	walletManager.injectedProvider = walletChainId ? { request: vi.fn() } : null;
+
+	// Mock fetch to prevent version check errors
+	vi.stubGlobal('fetch', vi.fn(async () => ({
+		ok: true,
+		text: async () => ''
+	})));
+
+	// Trigger DOMContentLoaded to initialize network badge
+	window.history.replaceState({}, '', `/?chain=${selectedSlug}`);
+	document.dispatchEvent(new Event('DOMContentLoaded'));
+
+	return app;
+}
+
+describe('Header wallet connection independence (issue #153)', () => {
+	let originalLocation;
+
+	beforeEach(() => {
+		originalLocation = window.location;
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+	document.body.innerHTML = '';
+	window.history.replaceState({}, '', '/');
+	walletManager.chainId = null;
+	walletManager.injectedProvider = null;
+	});
+
+	describe('syncNetworkBadgeFromState', () => {
+		it('shows selected network without wallet connection status classes', () => {
+			const app = initializeApp({
+				walletChainId: BNB_CHAIN_ID,
+				selectedSlug: POLYGON_SLUG,
+			});
+
+			const networkBadge = document.querySelector('.network-badge');
+			const networkButton = document.querySelector('.network-button');
+			const networkDropdown = document.querySelector('.network-dropdown');
+
+			// Network badge should show selected network (Polygon)
+			expect(networkBadge?.textContent).toContain('Polygon');
+
+			// Should NOT have wallet connection status classes
+			expect(networkBadge?.classList.contains('connected')).toBe(false);
+			expect(networkBadge?.classList.contains('wrong-network')).toBe(false);
+			expect(networkBadge?.classList.contains('setup-needed')).toBe(false);
+			expect(networkBadge?.classList.contains('disconnected')).toBe(false);
+
+			// Should have default status
+			expect(networkButton?.dataset.networkStatus).toBe('default');
+			expect(networkDropdown?.dataset.networkStatus).toBe('default');
+		});
+
+		it('shows selected network even when wallet is on different chain', () => {
+			const app = initializeApp({
+				walletChainId: BNB_CHAIN_ID, // Wallet on BNB
+				selectedSlug: POLYGON_SLUG, // App on Polygon
+			});
+
+			const networkBadge = document.querySelector('.network-badge');
+
+			// Network badge should show selected network (Polygon), not wallet network (BNB)
+			expect(networkBadge?.textContent).toContain('Polygon');
+			expect(networkBadge?.classList.contains('wrong-network')).toBe(false);
+		});
+
+		it('shows selected network even when wallet is on same chain', () => {
+			const polygonChainId = getNetworkBySlug(POLYGON_SLUG)?.chainId;
+			const app = initializeApp({
+				walletChainId: polygonChainId,
+				selectedSlug: POLYGON_SLUG,
+			});
+
+			const networkBadge = document.querySelector('.network-badge');
+
+			// Network badge should show selected network (Polygon)
+			expect(networkBadge?.textContent).toContain('Polygon');
+			// Should NOT have 'connected' class (wallet connection status is separate)
+			expect(networkBadge?.classList.contains('connected')).toBe(false);
+		});
+
+		it('shows selected network when no wallet is connected', () => {
+			const app = initializeApp({
+				walletChainId: null,
+				selectedSlug: POLYGON_SLUG,
+			});
+
+			const networkBadge = document.querySelector('.network-badge');
+
+			// Network badge should show selected network (Polygon)
+			expect(networkBadge?.textContent).toContain('Polygon');
+			// Should NOT have 'disconnected' class
+			expect(networkBadge?.classList.contains('disconnected')).toBe(false);
+		});
+	});
+
+	describe('handleNetworkSelectionCommit', () => {
+		it('does not call switchWalletToNetwork when wallet is connected', async () => {
+			const polygonChainId = getNetworkBySlug(POLYGON_SLUG)?.chainId;
+			const app = initializeApp({
+				walletChainId: BNB_CHAIN_ID, // Wallet on BNB
+				selectedSlug: ETHEREUM_SLUG, // App on Ethereum
+			});
+
+			const targetNetwork = getNetworkBySlug(POLYGON_SLUG);
+			const switchSpy = vi.spyOn(app, 'switchWalletToNetwork');
+
+			await app.handleNetworkSelectionCommit(targetNetwork);
+
+			// Should NOT call switchWalletToNetwork
+			expect(switchSpy).not.toHaveBeenCalled();
+
+			// Should trigger page reload to refresh app state
+			expect(window.location.reload).toHaveBeenCalled();
+		});
+
+		it('triggers page reload to refresh app state and services', async () => {
+			const app = initializeApp({
+				walletChainId: BNB_CHAIN_ID,
+				selectedSlug: ETHEREUM_SLUG,
+			});
+
+			const targetNetwork = getNetworkBySlug(POLYGON_SLUG);
+
+			await app.handleNetworkSelectionCommit(targetNetwork);
+
+			// Should trigger page reload
+			expect(window.location.reload).toHaveBeenCalled();
+		});
+
+		it('does not trigger page reload when network is null', async () => {
+			const app = initializeApp({
+				walletChainId: BNB_CHAIN_ID,
+				selectedSlug: ETHEREUM_SLUG,
+			});
+
+			await app.handleNetworkSelectionCommit(null);
+
+			// Should NOT trigger page reload
+			expect(window.location.reload).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('add network button visibility', () => {
+		it('hides add network button by default (network selection does not trigger wallet operations)', () => {
+			const app = initializeApp({
+				walletChainId: BNB_CHAIN_ID,
+				selectedSlug: POLYGON_SLUG,
+			});
+
+			const addNetworkButton = document.getElementById('addNetworkButton');
+
+			// Add network button should be hidden by default
+			expect(addNetworkButton?.classList.contains('hidden')).toBe(true);
+		});
+
+		it('shows add network button when network setup is required after failed switch', () => {
+			const app = initializeApp({
+				walletChainId: BNB_CHAIN_ID,
+				selectedSlug: POLYGON_SLUG,
+			});
+
+			const targetNetwork = getNetworkBySlug(POLYGON_SLUG);
+			const error = Object.assign(new Error('Unrecognized chain'), {
+				code: 4902,
+				requiresWalletNetworkAddition: true,
+			});
+			walletManager.injectedProvider = { request: vi.fn() };
+
+			app.handleNetworkSwitchFailure(error, targetNetwork, {
+				restoreSelectionNetwork: targetNetwork,
+			});
+
+			const addNetworkButton = document.getElementById('addNetworkButton');
+
+			// Add network button should be visible after failed switch
+			expect(addNetworkButton?.classList.contains('hidden')).toBe(false);
+			expect(addNetworkButton?.textContent).toBe('Add Polygon Mainnet');
+		});
+	});
+});

--- a/tests/app.headerWalletIndependence.test.js
+++ b/tests/app.headerWalletIndependence.test.js
@@ -177,6 +177,19 @@ describe('Header wallet connection independence (issue #153)', () => {
 				selectedSlug: ETHEREUM_SLUG, // App on Ethereum
 			});
 
+			// Mock methods needed for in-app transition
+			app.updateTabVisibility = vi.fn();
+			app.refreshAdminTabVisibility = vi.fn(async () => {});
+			app.refreshClaimTabVisibility = vi.fn(async () => {});
+			app.refreshOrderTabVisibility = vi.fn(async () => {});
+			app.recreateNetworkServices = vi.fn(async () => {});
+			app.reinitializeComponents = vi.fn(async () => {});
+			app.showTab = vi.fn(async () => {});
+			app.isTabVisible = vi.fn(() => true);
+			app.startInitialOrderSync = vi.fn();
+			app.currentTab = 'view-orders';
+			app.components = {};
+
 			const targetNetwork = getNetworkBySlug(POLYGON_SLUG);
 			const switchSpy = vi.spyOn(app, 'switchWalletToNetwork');
 
@@ -185,13 +198,47 @@ describe('Header wallet connection independence (issue #153)', () => {
 			// Should NOT call switchWalletToNetwork
 			expect(switchSpy).not.toHaveBeenCalled();
 
-			// Should trigger page reload to refresh app state
-			expect(window.location.reload).toHaveBeenCalled();
+			// Should NOT trigger page reload for connected users (uses in-app transition)
+			expect(window.location.reload).not.toHaveBeenCalled();
 		});
 
-		it('triggers page reload to refresh app state and services', async () => {
+		it('uses in-app transition for connected users to preserve navigation context', async () => {
 			const app = initializeApp({
 				walletChainId: BNB_CHAIN_ID,
+				selectedSlug: ETHEREUM_SLUG,
+			});
+
+			// Mock methods needed for in-app transition
+			app.updateTabVisibility = vi.fn();
+			app.refreshAdminTabVisibility = vi.fn(async () => {});
+			app.refreshClaimTabVisibility = vi.fn(async () => {});
+			app.refreshOrderTabVisibility = vi.fn(async () => {});
+			app.recreateNetworkServices = vi.fn(async () => {});
+			app.reinitializeComponents = vi.fn(async () => {});
+			app.showTab = vi.fn(async () => {});
+			app.isTabVisible = vi.fn(() => true);
+			app.startInitialOrderSync = vi.fn();
+			app.currentTab = 'view-orders';
+			app.components = {};
+
+			const targetNetwork = getNetworkBySlug(POLYGON_SLUG);
+			const transitionSpy = vi.spyOn(app, 'handleSuccessfulConnectedNetworkTransition');
+
+			await app.handleNetworkSelectionCommit(targetNetwork);
+
+			// Should use in-app transition for connected users
+			expect(transitionSpy).toHaveBeenCalledWith(targetNetwork, {
+				source: 'network-selector',
+				selectedChainChanged: false,
+			});
+
+			// Should NOT trigger page reload
+			expect(window.location.reload).not.toHaveBeenCalled();
+		});
+
+		it('triggers page reload for disconnected users', async () => {
+			const app = initializeApp({
+				walletChainId: null, // No wallet connected
 				selectedSlug: ETHEREUM_SLUG,
 			});
 
@@ -199,7 +246,7 @@ describe('Header wallet connection independence (issue #153)', () => {
 
 			await app.handleNetworkSelectionCommit(targetNetwork);
 
-			// Should trigger page reload
+			// Should trigger page reload for disconnected users
 			expect(window.location.reload).toHaveBeenCalled();
 		});
 


### PR DESCRIPTION
## Summary
Implements Phase 2: Make header/network selector reflect wallet connection independently from wallet chain match.

## Scope
- Remove persistent correct-network / wrong-network indicator semantics from the wallet/network header controls
- The wallet-connected control should only care whether a wallet is connected
- The network dropdown should act as an app network selector only
- Selecting a network should update app state/read services without invoking wallet switch/add-network

## Acceptance Criteria
- [ ] A connected wallet on a non-selected chain still renders as connected
- [ ] Dropdown selection no longer calls switch/add-network
- [ ] Selected-network changes still refresh app state/services correctly
- [ ] Regression coverage added for header/dropdown behavior

## Work in Progress
Starting implementation...