### PR TITLE
Phase 2: move component read paths off WebSocket

### DIFF
--- a/js/components/Admin.js
+++ b/js/components/Admin.js
@@ -40,10 +40,8 @@ export class Admin extends BaseComponent {
         this.isInitializing = true;
 
         try {
-            const ws = this.ctx.getWebSocket();
-            await ws?.waitForInitialization();
-
-            this.contract = ws?.contract;
+            // Use HTTP for reads so Admin never blocks on WS readiness.
+            this.contract = await contractService.readViaHttpRpc(({ contract: httpContract }) => httpContract);
             if (!this.contract) {
                 throw new Error('Contract not initialized');
             }

--- a/js/components/Claim.js
+++ b/js/components/Claim.js
@@ -6,6 +6,7 @@ import { generateTokenIconHTML } from '../utils/tokenIcons.js';
 import { getClaimableSnapshot } from '../utils/claims.js';
 import { buildTokenDisplaySymbolMap, getDisplaySymbol } from '../utils/tokenDisplay.js';
 import { escapeHtml } from '../utils/html.js';
+import { contractService } from '../services/ContractService.js';
 
 export class Claim extends BaseComponent {
     constructor(containerId = 'claim') {
@@ -45,9 +46,9 @@ export class Claim extends BaseComponent {
 
         try {
             const ws = this.ctx.getWebSocket();
-            await ws?.waitForInitialization?.();
             this.webSocket = ws;
-            this.contract = ws?.contract || null;
+            // Use HTTP for reads so Claim never blocks on WS readiness.
+            this.contract = await contractService.readViaHttpRpc(({ contract: httpContract }) => httpContract);
 
             this.renderShell();
             this.container.removeEventListener('click', this.handleContainerClick);

--- a/js/components/CreateOrder.js
+++ b/js/components/CreateOrder.js
@@ -634,20 +634,12 @@ export class CreateOrder extends BaseComponent {
                 }
             }
 
+            // CreateOrder should not depend on WS readiness. It only needs:
+            // - HTTP reads for config/allowed tokens/balances
+            // - wallet signer for writes
             const ws = this.ctx.getWebSocket();
-            // CreateOrder only creates orders, it doesn't need to listen to order events
-
-            // Wait for WebSocket to be fully initialized
             if (!ws?.isInitialized) {
-                this.debug('Waiting for WebSocket initialization...');
-                await new Promise(resolve => {
-                    const checkInterval = setInterval(() => {
-                        if (ws?.isInitialized) {
-                            clearInterval(checkInterval);
-                            resolve();
-                        }
-                    }, 100);
-                });
+                this.debug('WebSocket not ready yet; continuing with HTTP-only reads');
             }
 
             // Clear existing content before re-populating
@@ -656,16 +648,14 @@ export class CreateOrder extends BaseComponent {
             if (sellContainer) sellContainer.innerHTML = '';
             if (buyContainer) buyContainer.innerHTML = '';
 
-            // Use WebSocket's contract instance
-            this.contract = ws.contract;
-            this.provider = ws.provider;
+            // Use HTTP contract/provider for reads so network switching can't
+            // strand balances in "loading...".
+            this.contract = await contractService.readViaHttpRpc(({ contract }) => contract);
+            this.provider = contractService.getHttpProvider();
 
             if (!this.contract) {
-                throw new Error('Contract not initialized');
+                throw new Error('HTTP contract not initialized');
             }
-            
-            // Initialize contract service
-            contractService.initialize();
             
             if (readOnlyMode) {
                 this.setReadOnlyMode();

--- a/js/components/MyOrders.js
+++ b/js/components/MyOrders.js
@@ -180,7 +180,8 @@ export class MyOrders extends BaseComponent {
                 Array.from(ws.tokenCache.values()),
                 this.ctx?.getWalletChainId?.()
             );
-            await ws.ensureChainTimeInitialized();
+            // Never block first render / refresh on chain-time bootstrap.
+            ws.ensureChainTimeInitialized().catch(() => {});
             let ordersToDisplay = Array.from(ws.orderCache.values());
             
             // Filter for user's orders only

--- a/js/components/TakerOrders.js
+++ b/js/components/TakerOrders.js
@@ -100,7 +100,8 @@ export class TakerOrders extends BaseComponent {
                 Array.from(ws.tokenCache.values()),
                 this.ctx?.getWalletChainId?.()
             );
-            await ws.ensureChainTimeInitialized();
+            // Never block first render / refresh on chain-time bootstrap.
+            ws.ensureChainTimeInitialized().catch(() => {});
             let ordersToDisplay = Array.from(ws.orderCache.values())
                 .filter(order => 
                     order?.taker && 

--- a/js/components/ViewOrders.js
+++ b/js/components/ViewOrders.js
@@ -134,7 +134,9 @@ export class ViewOrders extends BaseComponent {
                 Array.from(ws.tokenCache.values()),
                 this.ctx?.getWalletChainId?.()
             );
-            await ws.ensureChainTimeInitialized();
+            // Never block first render / refresh on chain-time bootstrap.
+            // Expiry checks fall back to local wall-clock when chain time is unknown.
+            ws.ensureChainTimeInitialized().catch(() => {});
             let ordersToDisplay = Array.from(ws.orderCache.values());
             
             // Apply token filters

--- a/js/services/MulticallService.js
+++ b/js/services/MulticallService.js
@@ -26,7 +26,9 @@ function getMulticallContract(providerOverride = null) {
 			return null;
 		}
 
-		const provider = providerOverride || contractService.getProvider();
+		// Multicall is a *read path*; prefer HTTP so WS socket flaps cannot
+		// strand balance reads on network switches.
+		const provider = providerOverride || contractService.getHttpProvider() || contractService.getProvider();
 		if (!provider) {
 			debug('No provider available for Multicall');
 			return null;

--- a/js/services/OrdersComponentHelper.js
+++ b/js/services/OrdersComponentHelper.js
@@ -299,9 +299,13 @@ export class OrdersComponentHelper {
                 await new Promise(resolve => setTimeout(resolve, 1000));
                 return this.initWebSocket(onRefresh); // Retry
             }
-
-            // Wait for WebSocket to be fully initialized
-            await ws.waitForInitialization();
+            // Never block UI initialization on WebSocket readiness.
+            // Public WS endpoints can be intermittently slow; waiting here can
+            // strand the global loader during rapid network toggles (especially
+            // when a wallet reconnects on reload).
+            void ws.waitForInitialization()
+                .then(() => this.setupWebSocket(onRefresh))
+                .catch((error) => this.debug('WebSocket not ready yet:', error));
             
             // Get current account
             const wallet = this.component.ctx.getWallet();
@@ -323,7 +327,7 @@ export class OrdersComponentHelper {
             };
             wallet?.addListener(this.component.walletListener);
             
-            // Setup WebSocket subscriptions
+            // Setup subscriptions opportunistically (will no-op until provider exists).
             await this.setupWebSocket(onRefresh);
             
             this.debug('WebSocket initialization complete');
@@ -504,6 +508,8 @@ export class OrdersComponentHelper {
                 throw new Error(`Order is not active (status: ${getOrderStatusText(currentOrderStatus)})`);
             }
 
+            // This path is about *validating a transaction* (not first paint),
+            // so we still want chain time. But do not hang forever.
             await ws.ensureChainTimeInitialized();
             const now = ws.getCurrentTimestamp();
             if (!Number.isFinite(now)) {

--- a/js/services/OrdersTableRenderer.js
+++ b/js/services/OrdersTableRenderer.js
@@ -736,7 +736,8 @@ export class OrdersTableRenderer {
             const order = ws.orderCache.get(Number(orderId));
             if (!order) return;
 
-            await ws.ensureChainTimeInitialized();
+            // Avoid blocking UI updates (row render) on chain-time bootstrap.
+            ws.ensureChainTimeInitialized().catch(() => {});
             const currentTime = ws.getCurrentTimestamp();
             const expiresAt = order?.timings?.expiresAt;
             const timeDiff = Number.isFinite(currentTime) && typeof expiresAt === 'number'

--- a/js/utils/contractTokens.js
+++ b/js/utils/contractTokens.js
@@ -210,7 +210,8 @@ async function getUserTokenBalance(tokenAddress) {
             return cached.value;
         }
         
-        const provider = contractService.getProvider();
+        // Balance reads should be HTTP-only; WS can flap during network switches.
+        const provider = contractService.getHttpProvider() || contractService.getProvider();
 
         // First, try multicall for decimals and balanceOf (single ABI source: erc20.js)
         const calls = [


### PR DESCRIPTION
## Summary

- move component startup and read-only paths away from WebSocket-coupled reads
- keep startup-safe reads on HTTP-backed helpers where possible
- reduce UI stalls caused by waiting on realtime transport

## Scope

- `CreateOrder`
- `Claim`
- `Admin`
- order views, helper, and renderer
- `MulticallService`
- contract token and balance helpers

## Stack

- base branch: `stack/reload-switch/01-app-lifecycle-reload`
- this PR should merge on top of Phase 1

## Testing

- `npm test -- tests/app.networkTransition.test.js tests/app.headerWalletIndependence.test.js tests/websocket.chainTimeBootstrap.test.js`