### PR TITLE
Phase 1: reload-first app lifecycle

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -734,6 +734,18 @@ class App {
 		}
 	}
 
+	getDefaultInitialTab(hasInitialConnectedContext = false) {
+		return hasInitialConnectedContext ? 'create-order' : 'view-orders';
+	}
+
+	resolveInitialTab(restoredTab, hasInitialConnectedContext = false) {
+		const fallbackTab = this.getDefaultInitialTab(hasInitialConnectedContext);
+		const normalizedRestoredTab = String(restoredTab || '').trim();
+		return normalizedRestoredTab && this.isTabVisible(normalizedRestoredTab)
+			? normalizedRestoredTab
+			: fallbackTab;
+	}
+
 	showGlobalLoader(message = 'Loading WhaleSwap...', options = {}) {
 		const { mode = null } = options;
 		if (window.__bootstrapLoaderTimeout) {
@@ -1324,12 +1336,13 @@ class App {
 				}
 			});
 
-			// Restore active tab from history state if available (PR #178 review)
+			// Restore active tab from history state if available (PR #178 review).
+			// Resolve it only after initial tab visibility has been applied; some
+			// tabs (for example cleanup-orders) start hidden in the HTML and are
+			// made visible by updateTabVisibility().
 			const historyState = window.history?.state || {};
 			const restoredTab = historyState[ACTIVE_TAB_STATE_KEY];
-			this.currentTab = (restoredTab && this.isTabVisible(restoredTab)) 
-				? restoredTab 
-				: (hasInitialConnectedContext ? 'create-order' : 'view-orders');
+			this.currentTab = this.getDefaultInitialTab(hasInitialConnectedContext);
 
 				// Add wallet connection state handler
 				walletManager.addListener(async (event, data) => {
@@ -1505,6 +1518,7 @@ class App {
 
 			// Update initial tab visibility based on wallet connection only.
 			this.updateTabVisibility(hasInitialConnectedContext);
+			this.currentTab = this.resolveInitialTab(restoredTab, hasInitialConnectedContext);
 			// Do not block first paint on owner check/network calls.
 			Promise.resolve()
 				.then(() => this.refreshAdminTabVisibility())

--- a/js/app.js
+++ b/js/app.js
@@ -713,6 +713,27 @@ class App {
 		}
 	}
 
+	persistActiveTabState(tabId = this.currentTab || 'view-orders') {
+		try {
+			const nextTabId = String(tabId || '').trim();
+			if (!nextTabId) {
+				return;
+			}
+
+			const historyState = window.history?.state || {};
+			window.history?.replaceState?.(
+				{
+					...historyState,
+					[ACTIVE_TAB_STATE_KEY]: nextTabId
+				},
+				'',
+				window.location.href
+			);
+		} catch (error) {
+			this.debug('Failed to persist active tab state:', error);
+		}
+	}
+
 	showGlobalLoader(message = 'Loading WhaleSwap...', options = {}) {
 		const { mode = null } = options;
 		if (window.__bootstrapLoaderTimeout) {
@@ -1846,6 +1867,7 @@ class App {
 
 			// Show and initialize selected tab
 			if (tabContent) {
+				this.persistActiveTabState(tabId);
 				tabContent.classList.add('active');
 
 				// Initialize component for this tab

--- a/js/app.js
+++ b/js/app.js
@@ -260,13 +260,18 @@ class App {
 			}
 
 			const ws = this.ctx?.getWebSocket?.();
-			await ws?.waitForInitialization?.();
 			if (!ws) {
 				return await applyVisibility(noOrderTabsVisibility);
 			}
 
+			// Never block UI on WebSocket readiness / order sync. If the cache
+			// isn't ready yet, keep tabs hidden and re-check shortly.
 			if (force || !ws.hasCompletedOrderSync) {
-				await ws.waitForOrderSync({ triggerIfNeeded: true });
+				void ws.waitForInitialization?.()
+					.then(() => ws.waitForOrderSync?.({ triggerIfNeeded: true }))
+					.then(() => this.scheduleOrderTabVisibilityRefresh({ force: false }))
+					.catch((error) => this.debug('Deferred order-tab visibility refresh failed:', error));
+				return await applyVisibility(noOrderTabsVisibility, { allowRedirect: false });
 			}
 
 			const orders = Array.from(ws.orderCache?.values?.() || []);
@@ -382,8 +387,9 @@ class App {
 				}
 
 			const ws = this.ctx?.getWebSocket?.();
-			await ws?.waitForInitialization?.();
-			const contract = ws?.contract;
+			// Do not block UI on WS readiness. Use HTTP contract reads for
+			// visibility checks to avoid stalls during rapid chain toggles.
+			const contract = await contractService.readViaHttpRpc(({ contract: httpContract }) => httpContract);
 				if (!contract) {
 					await applyVisibility(fallbackVisible, {
 						authoritative: false,
@@ -1119,10 +1125,15 @@ class App {
 
 		try {
 			await walletManager.switchToNetwork(resolvedTargetNetwork);
-			return await this.handleSuccessfulConnectedNetworkTransition(resolvedTargetNetwork, {
-				source,
-				selectedChainChanged,
+			// The wallet's chainChanged event (see handler above) will fire
+			// and trigger the full-reload path. Trigger it here as a safety
+			// net in case the wallet does not emit chainChanged (some
+			// providers skip the event when the chain is already correct).
+			triggerPageReloadWithSwitchFallback({
+				loaderMode: 'spinner',
+				loaderMessage: `Switching to ${getNetworkLabel(resolvedTargetNetwork)}...`
 			});
+			return true;
 		} catch (error) {
 			const pendingSwitchRequest = this.pendingWalletSwitchRequest;
 			if (this.pendingWalletSwitchRequest?.targetSlug === resolvedTargetNetwork.slug) {
@@ -1137,10 +1148,6 @@ class App {
 
 	async handleNetworkSelectionCommit(network, options = {}) {
 		if (!network) return;
-		const {
-			selectedChainChanged = false,
-			previousSelectedNetwork = null,
-		} = options;
 
 		try {
 			setActiveNetwork(network);
@@ -1149,24 +1156,15 @@ class App {
 			return;
 		}
 
-		// Issue #153: Network selection updates app state without triggering wallet operations
-		// For connected users, use in-app transition to preserve navigation context (PR #178 review)
-		const wallet = this.ctx?.getWallet?.();
-		const isConnected = !!wallet?.isWalletConnected?.() && !!wallet?.getSigner?.();
-		
-		if (isConnected) {
-			// Use in-app transition for connected users to preserve active tab
-			await this.handleSuccessfulConnectedNetworkTransition(network, {
-				source: 'network-selector',
-				selectedChainChanged,
-			});
-		} else {
-			// Use page reload for disconnected/read-only users
-			triggerPageReloadWithSwitchFallback({
-				loaderMode: 'spinner',
-				loaderMessage: `Switching to ${getNetworkLabel(network)}...`
-			});
-		}
+		// Network switches always do a full page reload. In-page transitions
+		// were a source of subtle bugs (stale WS subscriptions, orphaned
+		// promises, half-torn-down contracts). A reload gives a guaranteed
+		// clean slate, and the active tab is already preserved via
+		// ACTIVE_TAB_STATE_KEY in history.state (see persistBootstrapLoaderState).
+		triggerPageReloadWithSwitchFallback({
+			loaderMode: 'spinner',
+			loaderMessage: `Switching to ${getNetworkLabel(network)}...`
+		});
 	}
 
 	async load () {
@@ -1226,7 +1224,10 @@ class App {
 			this.updateGlobalLoaderText('Initializing pricing...');
 			await this.initializePricingService();
 			this.updateGlobalLoaderText('Connecting to order feed...');
-			await this.initializeWebSocket({ awaitReady: hasInitialConnectedContext });
+			// Never block initial paint (or reload-on-network-switch) on WS readiness.
+			// Public WS endpoints can be intermittently slow/rate-limited; any waits here
+			// can strand the global loader during rapid chain toggles.
+			await this.initializeWebSocket({ awaitReady: false });
 
 			// Initialize CreateOrder first
 			this.components = {
@@ -1368,16 +1369,18 @@ class App {
 							this.ctx.setWalletChainId(walletChainId);
 							syncNetworkBadgeFromState();
 
-								const selectedNetwork = this.getSelectedNetwork();
-								const walletNetwork = getNetworkById(walletChainId);
-								if (walletNetwork && walletNetwork.slug === selectedNetwork.slug) {
-									const pendingSwitchRequest = this.getPendingWalletSwitchRequest(walletNetwork);
-									await this.handleSuccessfulConnectedNetworkTransition(walletNetwork, {
-										source: pendingSwitchRequest?.source || 'chain-changed',
-										selectedChainChanged: Boolean(pendingSwitchRequest?.selectedChainChanged),
-										walletChainId,
-									});
-								} else {
+							const selectedNetwork = this.getSelectedNetwork();
+							const walletNetwork = getNetworkById(walletChainId);
+							if (walletNetwork && walletNetwork.slug === selectedNetwork.slug) {
+								// Wallet now matches the selected chain: do a full reload
+								// to adopt the new chain state from scratch (see
+								// handleNetworkSelectionCommit for rationale). The active
+								// tab is preserved via history.state.
+								triggerPageReloadWithSwitchFallback({
+									loaderMode: 'spinner',
+									loaderMessage: `Switching to ${getNetworkLabel(walletNetwork)}...`
+								});
+							} else {
 								this.updateTabVisibility(true);
 								await this.refreshAdminTabVisibility();
 								await this.refreshClaimTabVisibility();
@@ -1421,9 +1424,7 @@ class App {
 					// Keep hidden until owner check confirms visibility to avoid startup flicker.
 					adminButton.style.display = 'none';
 					const signer = await wallet.getSigner();
-					const ws = this.ctx.getWebSocket();
-					await ws?.waitForInitialization();
-					const contract = ws?.contract;
+					const contract = await contractService.readViaHttpRpc(({ contract: httpContract }) => httpContract);
 					if (!signer || !contract) throw new Error('Signer/contract unavailable');
 
 					const [owner, account] = await Promise.all([
@@ -1952,10 +1953,16 @@ class App {
 			// Ensure WebSocket is initialized and synced when preserving orders
 			if (preserveOrders && ws) {
 				try {
-					await ws.waitForInitialization();
-					if (ws.orderCache.size === 0) {
-						await ws.syncAllOrders();
-					}
+					// Never block connected-wallet reinit on WS readiness.
+					// If WS comes up later and the cache is empty, sync in background.
+					void ws.waitForInitialization()
+						.then(() => {
+							if (ws.orderCache.size === 0) {
+								return ws.syncAllOrders();
+							}
+							return null;
+						})
+						.catch((e) => this.debug('Deferred WS sync skipped/failed (preserveOrders)', e));
 				} catch (e) {
 					this.debug('WebSocket not ready during reinit (preserveOrders)', e);
 				}

--- a/tests/app.headerWalletIndependence.test.js
+++ b/tests/app.headerWalletIndependence.test.js
@@ -171,69 +171,37 @@ describe('Header wallet connection independence (issue #153)', () => {
 
 	describe('handleNetworkSelectionCommit', () => {
 		it('does not call switchWalletToNetwork when wallet is connected', async () => {
-			const polygonChainId = getNetworkBySlug(POLYGON_SLUG)?.chainId;
 			const app = initializeApp({
 				walletChainId: BNB_CHAIN_ID, // Wallet on BNB
 				selectedSlug: ETHEREUM_SLUG, // App on Ethereum
 			});
-
-			// Mock methods needed for in-app transition
-			app.updateTabVisibility = vi.fn();
-			app.refreshAdminTabVisibility = vi.fn(async () => {});
-			app.refreshClaimTabVisibility = vi.fn(async () => {});
-			app.refreshOrderTabVisibility = vi.fn(async () => {});
-			app.recreateNetworkServices = vi.fn(async () => {});
-			app.reinitializeComponents = vi.fn(async () => {});
-			app.showTab = vi.fn(async () => {});
-			app.isTabVisible = vi.fn(() => true);
-			app.startInitialOrderSync = vi.fn();
-			app.currentTab = 'view-orders';
-			app.components = {};
 
 			const targetNetwork = getNetworkBySlug(POLYGON_SLUG);
 			const switchSpy = vi.spyOn(app, 'switchWalletToNetwork');
 
 			await app.handleNetworkSelectionCommit(targetNetwork);
 
-			// Should NOT call switchWalletToNetwork
+			// Should NOT call switchWalletToNetwork - the header selector
+			// only updates the app's selected network, not the wallet.
 			expect(switchSpy).not.toHaveBeenCalled();
-
-			// Should NOT trigger page reload for connected users (uses in-app transition)
-			expect(window.location.reload).not.toHaveBeenCalled();
 		});
 
-		it('uses in-app transition for connected users to preserve navigation context', async () => {
+		it('triggers a full page reload for connected users', async () => {
 			const app = initializeApp({
 				walletChainId: BNB_CHAIN_ID,
 				selectedSlug: ETHEREUM_SLUG,
 			});
 
-			// Mock methods needed for in-app transition
-			app.updateTabVisibility = vi.fn();
-			app.refreshAdminTabVisibility = vi.fn(async () => {});
-			app.refreshClaimTabVisibility = vi.fn(async () => {});
-			app.refreshOrderTabVisibility = vi.fn(async () => {});
-			app.recreateNetworkServices = vi.fn(async () => {});
-			app.reinitializeComponents = vi.fn(async () => {});
-			app.showTab = vi.fn(async () => {});
-			app.isTabVisible = vi.fn(() => true);
-			app.startInitialOrderSync = vi.fn();
-			app.currentTab = 'view-orders';
-			app.components = {};
-
 			const targetNetwork = getNetworkBySlug(POLYGON_SLUG);
-			const transitionSpy = vi.spyOn(app, 'handleSuccessfulConnectedNetworkTransition');
 
 			await app.handleNetworkSelectionCommit(targetNetwork);
 
-			// Should use in-app transition for connected users
-			expect(transitionSpy).toHaveBeenCalledWith(targetNetwork, {
-				source: 'network-selector',
-				selectedChainChanged: false,
-			});
-
-			// Should NOT trigger page reload
-			expect(window.location.reload).not.toHaveBeenCalled();
+			// Network switches always do a full reload regardless of wallet
+			// connection state. The in-page transition path was a source of
+			// subtle bugs with stale WS subscriptions and half-torn-down
+			// contracts; a reload guarantees a clean slate. The active tab
+			// is preserved via ACTIVE_TAB_STATE_KEY in history.state.
+			expect(window.location.reload).toHaveBeenCalledTimes(1);
 		});
 
 		it('triggers page reload for disconnected users', async () => {

--- a/tests/app.networkTransition.test.js
+++ b/tests/app.networkTransition.test.js
@@ -151,6 +151,24 @@ describe('App active tab persistence', () => {
 			message: 'Switching network...'
 		});
 	});
+
+	it('restores cleanup-orders after initial visibility has been applied', () => {
+		document.body.innerHTML = `
+			<button class="tab-button" data-tab="create-order" style="display: block"></button>
+			<button class="tab-button" data-tab="view-orders" style="display: block"></button>
+			<button class="tab-button" data-tab="cleanup-orders" style="display: none"></button>
+		`;
+
+		const AppCtor = window.app.constructor;
+		const app = new AppCtor();
+
+		expect(app.resolveInitialTab('cleanup-orders', true)).toBe('create-order');
+
+		app.setTabVisible('cleanup-orders', true);
+
+		expect(app.resolveInitialTab('cleanup-orders', true)).toBe('cleanup-orders');
+		expect(app.resolveInitialTab('claim', false)).toBe('view-orders');
+	});
 });
 
 describe('BaseComponent ensureWalletReadyForWrite', () => {

--- a/tests/app.networkTransition.test.js
+++ b/tests/app.networkTransition.test.js
@@ -111,6 +111,48 @@ describe('App network transition behavior', () => {
 	});
 });
 
+describe('App active tab persistence', () => {
+	it('persists the selected tab in history state when showTab succeeds', async () => {
+		document.body.innerHTML = `
+			<button class="tab-button" data-tab="view-orders"></button>
+			<button class="tab-button" data-tab="cleanup-orders"></button>
+			<div id="view-orders" class="tab-content"></div>
+			<div id="cleanup-orders" class="tab-content"></div>
+		`;
+		window.history.replaceState(
+			{
+				whaleswapBootstrapLoader: {
+					mode: 'spinner',
+					message: 'Switching network...'
+				}
+			},
+			'',
+			'/'
+		);
+
+		const AppCtor = window.app.constructor;
+		const app = new AppCtor();
+		app.ctx = {
+			getWallet: () => ({
+				isWalletConnected: () => true,
+			}),
+		};
+		app.components = {};
+		app.refreshAdminTabVisibility = vi.fn(async () => false);
+		app.refreshClaimTabVisibility = vi.fn(async () => false);
+		app.refreshOrderTabVisibility = vi.fn(async () => ({ showMyOrders: false, showInvitedOrders: false }));
+		app.tabReady = new Set();
+
+		await app.showTab('cleanup-orders', false, { skipInitialize: true });
+
+		expect(window.history.state?.whaleswapActiveTab).toBe('cleanup-orders');
+		expect(window.history.state?.whaleswapBootstrapLoader).toEqual({
+			mode: 'spinner',
+			message: 'Switching network...'
+		});
+	});
+});
+
 describe('BaseComponent ensureWalletReadyForWrite', () => {
 	it('continues the write flow after a successful in-place network switch', async () => {
 		document.body.innerHTML = '<div id="test-component"></div>';

--- a/tests/app.networkTransition.test.js
+++ b/tests/app.networkTransition.test.js
@@ -56,95 +56,58 @@ function createConnectedApp({
 	return { app, createOrderComponent };
 }
 
+let originalLocation;
+
 afterEach(() => {
 	document.body.innerHTML = '';
 	window.history.replaceState({}, '', '/');
 	walletManager.chainId = null;
 	setActiveNetwork(getNetworkBySlug('polygon'));
+	if (originalLocation) {
+		Object.defineProperty(window, 'location', {
+			configurable: true,
+			writable: true,
+			value: originalLocation,
+		});
+		originalLocation = null;
+	}
 	vi.restoreAllMocks();
 });
 
+function stubWindowLocationReload() {
+	originalLocation = window.location;
+	Object.defineProperty(window, 'location', {
+		configurable: true,
+		writable: true,
+		value: {
+			...window.location,
+			reload: vi.fn(),
+		},
+	});
+}
+
 describe('App network transition behavior', () => {
-	it('uses the lightweight same-chain path when the wallet catches up to the selected network', async () => {
+	it('triggers a full page reload after a successful wallet network switch', async () => {
 		const targetNetwork = getNetworkBySlug('polygon');
 		const { app } = createConnectedApp();
+		stubWindowLocationReload();
 		const switchSpy = vi.spyOn(walletManager, 'switchToNetwork').mockResolvedValue(targetNetwork);
+		const prepareSpy = vi.spyOn(app, 'prepareForNetworkReload');
 
-		await app.switchWalletToNetwork(targetNetwork, {
+		const result = await app.switchWalletToNetwork(targetNetwork, {
 			source: 'write:create the order',
 			selectedChainChanged: false,
 		});
 
+		expect(result).toBe(true);
 		expect(switchSpy).toHaveBeenCalledWith(targetNetwork);
+		// No in-page transition code paths should run; the reload gives
+		// us a guaranteed clean slate.
 		expect(app.recreateNetworkServices).not.toHaveBeenCalled();
 		expect(app.reinitializeComponents).not.toHaveBeenCalled();
-		expect(app.showGlobalLoader).not.toHaveBeenCalled();
-		expect(app.refreshActiveComponent).toHaveBeenCalledTimes(1);
-	});
-
-	it('dedupes repeated successful transitions for the same network', async () => {
-		const targetNetwork = getNetworkBySlug('bnb');
-		const { app } = createConnectedApp();
-		let resolveTransition;
-		app.recreateNetworkServices.mockImplementation(
-			() => new Promise((resolve) => {
-				resolveTransition = resolve;
-			})
-		);
-
-		const firstTransition = app.handleSuccessfulConnectedNetworkTransition(targetNetwork, {
-			source: 'switch-call',
-			selectedChainChanged: true,
-		});
-		const secondTransition = app.handleSuccessfulConnectedNetworkTransition(targetNetwork, {
-			source: 'chain-changed',
-			selectedChainChanged: true,
-		});
-
-		expect(app.recreateNetworkServices).toHaveBeenCalledTimes(1);
-
-		resolveTransition();
-		await expect(Promise.all([firstTransition, secondTransition])).resolves.toEqual([true, true]);
-	});
-
-	it('preserves create-order form state on same-chain alignment without snapshotting or reinit', async () => {
-		const targetNetwork = getNetworkBySlug('polygon');
-		const { app } = createConnectedApp();
-
-		await app.handleSuccessfulConnectedNetworkTransition(targetNetwork, {
-			source: 'write:create the order',
-			selectedChainChanged: false,
-		});
-
-		expect(app.reinitializeComponents).not.toHaveBeenCalled();
-		expect(app.refreshActiveComponent).toHaveBeenCalledTimes(1);
-	});
-
-	it('clears create-order state when the selected chain changes explicitly', async () => {
-		const targetNetwork = getNetworkBySlug('bnb');
-		const { app, createOrderComponent } = createConnectedApp({
-			currentTab: 'claim',
-			isCurrentTabVisible: false,
-			snapshot: {
-				selectedChainSlug: 'polygon',
-				sellAmount: '9',
-			},
-		});
-
-		await app.handleSuccessfulConnectedNetworkTransition(targetNetwork, {
-			source: 'network-selector',
-			selectedChainChanged: true,
-		});
-
-		expect(app.recreateNetworkServices).toHaveBeenCalledTimes(1);
-		expect(app.reinitializeComponents).toHaveBeenCalledWith(expect.objectContaining({
-			createOrderResetOptions: {
-				clearSelections: true,
-			},
-		}));
-		expect(app.showTab).toHaveBeenCalledWith('create-order', false, {
-			skipInitialize: true,
-		});
+		expect(app.refreshActiveComponent).not.toHaveBeenCalled();
+		expect(prepareSpy).toHaveBeenCalledTimes(1);
+		expect(window.location.reload).toHaveBeenCalledTimes(1);
 	});
 });
 


### PR DESCRIPTION
## Summary

- switch network transitions to a reload-first lifecycle instead of in-place teardown/rebuild
- preserve active tab and bootstrap loader state across reload
- persist the active tab in `history.state` whenever `showTab()` succeeds so reload restore is reliable for tabs like `cleanup-orders`
- resolve the restored tab only after initial tab visibility has been applied, so tabs that start hidden in the HTML can still restore correctly after reload
- start WebSocket initialization in the background so first paint is not blocked

## Scope

- app lifecycle and network transition flow
- active-tab persistence in `history.state`
- initial restored-tab resolution after visibility setup
- related app-level tests for reload behavior and tab restore

## Stack

- base of the reload-switch stack
- target branch: `main`

## Testing

- `npm test -- tests/app.networkTransition.test.js tests/app.headerWalletIndependence.test.js tests/websocket.chainTimeBootstrap.test.js`