### PR TITLE
Fix wallet-only network alignment without reload

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1216,15 +1216,14 @@ class App {
 		}
 
 		if (selectedChainChanged === false) {
-			const walletChainId = walletManager.chainId;
-			const walletNetwork = getNetworkById(walletChainId);
-			if (walletNetwork?.slug === resolvedTargetNetwork.slug) {
-				await this.handleSuccessfulConnectedNetworkTransition(resolvedTargetNetwork, {
-					source,
-					selectedChainChanged: false,
-					walletChainId,
-				});
-			}
+			const walletChainId = getNetworkById(walletManager.chainId)?.slug === resolvedTargetNetwork.slug
+				? walletManager.chainId
+				: resolvedTargetNetwork.chainId;
+			await this.handleSuccessfulConnectedNetworkTransition(resolvedTargetNetwork, {
+				source,
+				selectedChainChanged: false,
+				walletChainId,
+			});
 			return true;
 		}
 

--- a/js/app.js
+++ b/js/app.js
@@ -69,6 +69,7 @@ class App {
 		this.activeNetworkTransitionPromise = null;
 		this.activeNetworkTransitionSlug = null;
 		this.pendingWalletSwitchRequest = null;
+		this.skipNextWalletAlignedReloadTargetSlug = null;
 
 		// Replace debug initialization with LogService
 		const logger = createLogger('APP');
@@ -902,6 +903,9 @@ class App {
 	handleNetworkSwitchFailure(error, targetNetwork, options = {}) {
 		const { restoreSelectionNetwork = null } = options;
 		this.warn('Wallet network switch rejected/failed:', error);
+		if (this.skipNextWalletAlignedReloadTargetSlug === targetNetwork?.slug) {
+			this.skipNextWalletAlignedReloadTargetSlug = null;
+		}
 		const missingNetwork = isNetworkAddRequiredError(error);
 		const restoredNetwork = this.restoreSelectedNetwork(restoreSelectionNetwork);
 		if (missingNetwork && restoredNetwork?.slug === targetNetwork?.slug) {
@@ -939,6 +943,46 @@ class App {
 		}
 
 		return this.pendingWalletSwitchRequest;
+	}
+
+	async handleWalletChainChangedEvent(walletChainId) {
+		this.debug('Chain changed event received:', walletChainId);
+		this.ctx.setWalletChainId(walletChainId);
+		syncNetworkBadgeFromState();
+
+		const selectedNetwork = this.getSelectedNetwork();
+		const walletNetwork = getNetworkById(walletChainId);
+		if (walletNetwork && walletNetwork.slug === selectedNetwork.slug) {
+			if (this.skipNextWalletAlignedReloadTargetSlug === walletNetwork.slug) {
+				this.skipNextWalletAlignedReloadTargetSlug = null;
+				return;
+			}
+
+			const pendingSwitchRequest = this.getPendingWalletSwitchRequest(walletNetwork);
+			if (pendingSwitchRequest?.selectedChainChanged === false) {
+				await this.handleSuccessfulConnectedNetworkTransition(walletNetwork, {
+					source: pendingSwitchRequest.source || 'wallet:chainChanged',
+					selectedChainChanged: false,
+					walletChainId,
+				});
+				return;
+			}
+
+			// Wallet now matches the selected chain: do a full reload
+			// to adopt the new chain state from scratch (see
+			// handleNetworkSelectionCommit for rationale). The active
+			// tab is preserved via history.state.
+			triggerPageReloadWithSwitchFallback({
+				loaderMode: 'spinner',
+				loaderMessage: `Switching to ${getNetworkLabel(walletNetwork)}...`
+			});
+			return;
+		}
+
+		this.updateTabVisibility(true);
+		await this.refreshAdminTabVisibility();
+		await this.refreshClaimTabVisibility();
+		await this.refreshOrderTabVisibility();
 	}
 
 	subscribeToAppWebSocketEvents(ws = this.ctx?.getWebSocket?.()) {
@@ -1070,10 +1114,14 @@ class App {
 			});
 
 			if (!requiresNetworkDataRefresh) {
-				return await this.handleWalletAlignedToSelectedNetwork(targetNetwork, {
+				const result = await this.handleWalletAlignedToSelectedNetwork(targetNetwork, {
 					source,
 					walletChainId,
 				});
+				if (this.pendingWalletSwitchRequest?.targetSlug === targetNetwork.slug) {
+					this.pendingWalletSwitchRequest = null;
+				}
+				return result;
 			}
 
 			this.showGlobalLoader(`Switching to ${getNetworkLabel(targetNetwork)}...`, { mode: 'spinner' });
@@ -1158,6 +1206,20 @@ class App {
 
 		try {
 			await walletManager.switchToNetwork(resolvedTargetNetwork);
+			if (selectedChainChanged === false) {
+				const walletChainId = walletManager.chainId;
+				const walletNetwork = getNetworkById(walletChainId);
+				if (walletNetwork?.slug === resolvedTargetNetwork.slug) {
+					this.skipNextWalletAlignedReloadTargetSlug = resolvedTargetNetwork.slug;
+					await this.handleSuccessfulConnectedNetworkTransition(resolvedTargetNetwork, {
+						source,
+						selectedChainChanged: false,
+						walletChainId,
+					});
+				}
+				return true;
+			}
+
 			// The wallet's chainChanged event (see handler above) will fire
 			// and trigger the full-reload path. Trigger it here as a safety
 			// net in case the wallet does not emit chainChanged (some
@@ -1398,28 +1460,7 @@ class App {
 					}
 					case 'chainChanged': {
 						try {
-							this.debug('Chain changed event received:', data?.chainId);
-							const walletChainId = data?.chainId || null;
-							this.ctx.setWalletChainId(walletChainId);
-							syncNetworkBadgeFromState();
-
-							const selectedNetwork = this.getSelectedNetwork();
-							const walletNetwork = getNetworkById(walletChainId);
-							if (walletNetwork && walletNetwork.slug === selectedNetwork.slug) {
-								// Wallet now matches the selected chain: do a full reload
-								// to adopt the new chain state from scratch (see
-								// handleNetworkSelectionCommit for rationale). The active
-								// tab is preserved via history.state.
-								triggerPageReloadWithSwitchFallback({
-									loaderMode: 'spinner',
-									loaderMessage: `Switching to ${getNetworkLabel(walletNetwork)}...`
-								});
-							} else {
-								this.updateTabVisibility(true);
-								await this.refreshAdminTabVisibility();
-								await this.refreshClaimTabVisibility();
-								await this.refreshOrderTabVisibility();
-							}
+							await this.handleWalletChainChangedEvent(data?.chainId || null);
 						} catch (error) {
 							console.error('[App] Error handling chainChanged:', error);
 						}

--- a/js/app.js
+++ b/js/app.js
@@ -70,6 +70,7 @@ class App {
 		this.activeNetworkTransitionSlug = null;
 		this.pendingWalletSwitchRequest = null;
 		this.skipNextWalletAlignedReloadTargetSlug = null;
+		this.skipNextWalletAlignedReloadTimer = null;
 
 		// Replace debug initialization with LogService
 		const logger = createLogger('APP');
@@ -904,7 +905,7 @@ class App {
 		const { restoreSelectionNetwork = null } = options;
 		this.warn('Wallet network switch rejected/failed:', error);
 		if (this.skipNextWalletAlignedReloadTargetSlug === targetNetwork?.slug) {
-			this.skipNextWalletAlignedReloadTargetSlug = null;
+			this.clearSkipNextWalletAlignedReload();
 		}
 		const missingNetwork = isNetworkAddRequiredError(error);
 		const restoredNetwork = this.restoreSelectedNetwork(restoreSelectionNetwork);
@@ -945,6 +946,24 @@ class App {
 		return this.pendingWalletSwitchRequest;
 	}
 
+	clearSkipNextWalletAlignedReload() {
+		if (this.skipNextWalletAlignedReloadTimer) {
+			clearTimeout(this.skipNextWalletAlignedReloadTimer);
+			this.skipNextWalletAlignedReloadTimer = null;
+		}
+		this.skipNextWalletAlignedReloadTargetSlug = null;
+	}
+
+	armSkipNextWalletAlignedReload(targetSlug) {
+		this.clearSkipNextWalletAlignedReload();
+		this.skipNextWalletAlignedReloadTargetSlug = targetSlug;
+		this.skipNextWalletAlignedReloadTimer = setTimeout(() => {
+			if (this.skipNextWalletAlignedReloadTargetSlug === targetSlug) {
+				this.clearSkipNextWalletAlignedReload();
+			}
+		}, 5000);
+	}
+
 	async handleWalletChainChangedEvent(walletChainId) {
 		this.debug('Chain changed event received:', walletChainId);
 		this.ctx.setWalletChainId(walletChainId);
@@ -954,7 +973,7 @@ class App {
 		const walletNetwork = getNetworkById(walletChainId);
 		if (walletNetwork && walletNetwork.slug === selectedNetwork.slug) {
 			if (this.skipNextWalletAlignedReloadTargetSlug === walletNetwork.slug) {
-				this.skipNextWalletAlignedReloadTargetSlug = null;
+				this.clearSkipNextWalletAlignedReload();
 				return;
 			}
 
@@ -1210,7 +1229,7 @@ class App {
 				const walletChainId = walletManager.chainId;
 				const walletNetwork = getNetworkById(walletChainId);
 				if (walletNetwork?.slug === resolvedTargetNetwork.slug) {
-					this.skipNextWalletAlignedReloadTargetSlug = resolvedTargetNetwork.slug;
+					this.armSkipNextWalletAlignedReload(resolvedTargetNetwork.slug);
 					await this.handleSuccessfulConnectedNetworkTransition(resolvedTargetNetwork, {
 						source,
 						selectedChainChanged: false,

--- a/js/app.js
+++ b/js/app.js
@@ -1110,14 +1110,16 @@ class App {
 			});
 
 			if (!requiresNetworkDataRefresh) {
-				const result = await this.handleWalletAlignedToSelectedNetwork(targetNetwork, {
-					source,
-					walletChainId,
-				});
-				if (this.pendingWalletSwitchRequest?.targetSlug === targetNetwork.slug) {
-					this.pendingWalletSwitchRequest = null;
+				try {
+					return await this.handleWalletAlignedToSelectedNetwork(targetNetwork, {
+						source,
+						walletChainId,
+					});
+				} finally {
+					if (this.pendingWalletSwitchRequest?.targetSlug === targetNetwork.slug) {
+						this.pendingWalletSwitchRequest = null;
+					}
 				}
-				return result;
 			}
 
 			this.showGlobalLoader(`Switching to ${getNetworkLabel(targetNetwork)}...`, { mode: 'spinner' });
@@ -1202,28 +1204,6 @@ class App {
 
 		try {
 			await walletManager.switchToNetwork(resolvedTargetNetwork);
-			if (selectedChainChanged === false) {
-				const walletChainId = walletManager.chainId;
-				const walletNetwork = getNetworkById(walletChainId);
-				if (walletNetwork?.slug === resolvedTargetNetwork.slug) {
-					await this.handleSuccessfulConnectedNetworkTransition(resolvedTargetNetwork, {
-						source,
-						selectedChainChanged: false,
-						walletChainId,
-					});
-				}
-				return true;
-			}
-
-			// The wallet's chainChanged event (see handler above) will fire
-			// and trigger the full-reload path. Trigger it here as a safety
-			// net in case the wallet does not emit chainChanged (some
-			// providers skip the event when the chain is already correct).
-			triggerPageReloadWithSwitchFallback({
-				loaderMode: 'spinner',
-				loaderMessage: `Switching to ${getNetworkLabel(resolvedTargetNetwork)}...`
-			});
-			return true;
 		} catch (error) {
 			const pendingSwitchRequest = this.pendingWalletSwitchRequest;
 			if (this.pendingWalletSwitchRequest?.targetSlug === resolvedTargetNetwork.slug) {
@@ -1234,6 +1214,29 @@ class App {
 			});
 			return false;
 		}
+
+		if (selectedChainChanged === false) {
+			const walletChainId = walletManager.chainId;
+			const walletNetwork = getNetworkById(walletChainId);
+			if (walletNetwork?.slug === resolvedTargetNetwork.slug) {
+				await this.handleSuccessfulConnectedNetworkTransition(resolvedTargetNetwork, {
+					source,
+					selectedChainChanged: false,
+					walletChainId,
+				});
+			}
+			return true;
+		}
+
+		// The wallet's chainChanged event (see handler above) will fire
+		// and trigger the full-reload path. Trigger it here as a safety
+		// net in case the wallet does not emit chainChanged (some
+		// providers skip the event when the chain is already correct).
+		triggerPageReloadWithSwitchFallback({
+			loaderMode: 'spinner',
+			loaderMessage: `Switching to ${getNetworkLabel(resolvedTargetNetwork)}...`
+		});
+		return true;
 	}
 
 	async handleNetworkSelectionCommit(network, options = {}) {

--- a/js/app.js
+++ b/js/app.js
@@ -69,8 +69,6 @@ class App {
 		this.activeNetworkTransitionPromise = null;
 		this.activeNetworkTransitionSlug = null;
 		this.pendingWalletSwitchRequest = null;
-		this.skipNextWalletAlignedReloadTargetSlug = null;
-		this.skipNextWalletAlignedReloadTimer = null;
 
 		// Replace debug initialization with LogService
 		const logger = createLogger('APP');
@@ -904,9 +902,6 @@ class App {
 	handleNetworkSwitchFailure(error, targetNetwork, options = {}) {
 		const { restoreSelectionNetwork = null } = options;
 		this.warn('Wallet network switch rejected/failed:', error);
-		if (this.skipNextWalletAlignedReloadTargetSlug === targetNetwork?.slug) {
-			this.clearSkipNextWalletAlignedReload();
-		}
 		const missingNetwork = isNetworkAddRequiredError(error);
 		const restoredNetwork = this.restoreSelectedNetwork(restoreSelectionNetwork);
 		if (missingNetwork && restoredNetwork?.slug === targetNetwork?.slug) {
@@ -946,25 +941,8 @@ class App {
 		return this.pendingWalletSwitchRequest;
 	}
 
-	clearSkipNextWalletAlignedReload() {
-		if (this.skipNextWalletAlignedReloadTimer) {
-			clearTimeout(this.skipNextWalletAlignedReloadTimer);
-			this.skipNextWalletAlignedReloadTimer = null;
-		}
-		this.skipNextWalletAlignedReloadTargetSlug = null;
-	}
-
-	armSkipNextWalletAlignedReload(targetSlug) {
-		this.clearSkipNextWalletAlignedReload();
-		this.skipNextWalletAlignedReloadTargetSlug = targetSlug;
-		this.skipNextWalletAlignedReloadTimer = setTimeout(() => {
-			if (this.skipNextWalletAlignedReloadTargetSlug === targetSlug) {
-				this.clearSkipNextWalletAlignedReload();
-			}
-		}, 5000);
-	}
-
 	async handleWalletChainChangedEvent(walletChainId) {
+		const previousWalletChainId = this.ctx?.getWalletChainId?.() ?? null;
 		this.debug('Chain changed event received:', walletChainId);
 		this.ctx.setWalletChainId(walletChainId);
 		syncNetworkBadgeFromState();
@@ -972,8 +950,7 @@ class App {
 		const selectedNetwork = this.getSelectedNetwork();
 		const walletNetwork = getNetworkById(walletChainId);
 		if (walletNetwork && walletNetwork.slug === selectedNetwork.slug) {
-			if (this.skipNextWalletAlignedReloadTargetSlug === walletNetwork.slug) {
-				this.clearSkipNextWalletAlignedReload();
+			if (String(previousWalletChainId ?? '').toLowerCase() === String(walletChainId ?? '').toLowerCase()) {
 				return;
 			}
 
@@ -1229,7 +1206,6 @@ class App {
 				const walletChainId = walletManager.chainId;
 				const walletNetwork = getNetworkById(walletChainId);
 				if (walletNetwork?.slug === resolvedTargetNetwork.slug) {
-					this.armSkipNextWalletAlignedReload(resolvedTargetNetwork.slug);
 					await this.handleSuccessfulConnectedNetworkTransition(resolvedTargetNetwork, {
 						source,
 						selectedChainChanged: false,

--- a/tests/app.networkTransition.test.js
+++ b/tests/app.networkTransition.test.js
@@ -167,13 +167,13 @@ describe('App network transition behavior', () => {
 		expect(window.location.reload).not.toHaveBeenCalled();
 	});
 
-	it('ignores the duplicate reload when chainChanged arrives after wallet-only alignment', async () => {
+	it('ignores a duplicate chainChanged after wallet-only alignment', async () => {
 		const targetNetwork = getNetworkBySlug('polygon');
 		const { app } = createConnectedApp({
 			walletChainId: BNB_CHAIN_ID,
 		});
 		stubWindowLocationReload();
-		app.skipNextWalletAlignedReloadTargetSlug = targetNetwork.slug;
+		app.ctx.getWalletChainId = () => POLYGON_CHAIN_ID;
 		const transitionSpy = vi.spyOn(app, 'handleSuccessfulConnectedNetworkTransition').mockResolvedValue(true);
 		const prepareSpy = vi.spyOn(app, 'prepareForNetworkReload');
 
@@ -182,7 +182,55 @@ describe('App network transition behavior', () => {
 		expect(transitionSpy).not.toHaveBeenCalled();
 		expect(prepareSpy).not.toHaveBeenCalled();
 		expect(window.location.reload).not.toHaveBeenCalled();
-		expect(app.skipNextWalletAlignedReloadTargetSlug).toBeNull();
+	});
+
+	it('clears pending wallet-only switch state when in-place alignment fails', async () => {
+		const targetNetwork = getNetworkBySlug('polygon');
+		const { app } = createConnectedApp({
+			walletChainId: BNB_CHAIN_ID,
+		});
+		const expectedError = new Error('alignment failed');
+		app.pendingWalletSwitchRequest = {
+			source: 'write:create the order',
+			selectedChainChanged: false,
+			previousSelectedSlug: targetNetwork.slug,
+			targetSlug: targetNetwork.slug,
+		};
+		vi.spyOn(app, 'handleWalletAlignedToSelectedNetwork').mockRejectedValue(expectedError);
+
+		await expect(
+			app.handleSuccessfulConnectedNetworkTransition(targetNetwork, {
+				source: 'write:create the order',
+				selectedChainChanged: false,
+				walletChainId: POLYGON_CHAIN_ID,
+			})
+		).rejects.toThrow('alignment failed');
+		expect(app.pendingWalletSwitchRequest).toBeNull();
+	});
+
+	it('does not report wallet switch failure when post-switch alignment fails', async () => {
+		const targetNetwork = getNetworkBySlug('polygon');
+		const { app } = createConnectedApp({
+			walletChainId: BNB_CHAIN_ID,
+		});
+		const expectedError = new Error('alignment failed');
+		const switchSpy = vi.spyOn(walletManager, 'switchToNetwork').mockImplementation(async () => {
+			walletManager.chainId = POLYGON_CHAIN_ID;
+			return targetNetwork;
+		});
+		const failureSpy = vi.spyOn(app, 'handleNetworkSwitchFailure');
+		vi.spyOn(app, 'handleWalletAlignedToSelectedNetwork').mockRejectedValue(expectedError);
+
+		await expect(
+			app.switchWalletToNetwork(targetNetwork, {
+				source: 'write:create the order',
+				selectedChainChanged: false,
+			})
+		).rejects.toThrow('alignment failed');
+
+		expect(switchSpy).toHaveBeenCalledWith(targetNetwork);
+		expect(failureSpy).not.toHaveBeenCalled();
+		expect(app.pendingWalletSwitchRequest).toBeNull();
 	});
 });
 

--- a/tests/app.networkTransition.test.js
+++ b/tests/app.networkTransition.test.js
@@ -140,6 +140,30 @@ describe('App network transition behavior', () => {
 		expect(window.location.reload).not.toHaveBeenCalled();
 	});
 
+	it('aligns in place when the wallet is already on the target chain but cached chain state is stale', async () => {
+		const targetNetwork = getNetworkBySlug('polygon');
+		const { app } = createConnectedApp({
+			walletChainId: BNB_CHAIN_ID,
+		});
+		stubWindowLocationReload();
+		const switchSpy = vi.spyOn(walletManager, 'switchToNetwork').mockResolvedValue(targetNetwork);
+		const transitionSpy = vi.spyOn(app, 'handleSuccessfulConnectedNetworkTransition').mockResolvedValue(true);
+
+		const result = await app.switchWalletToNetwork(targetNetwork, {
+			source: 'write:create the order',
+			selectedChainChanged: false,
+		});
+
+		expect(result).toBe(true);
+		expect(switchSpy).toHaveBeenCalledWith(targetNetwork);
+		expect(transitionSpy).toHaveBeenCalledWith(targetNetwork, {
+			source: 'write:create the order',
+			selectedChainChanged: false,
+			walletChainId: POLYGON_CHAIN_ID,
+		});
+		expect(window.location.reload).not.toHaveBeenCalled();
+	});
+
 	it('uses in-place alignment on chainChanged for pending wallet-only catch-up', async () => {
 		const targetNetwork = getNetworkBySlug('polygon');
 		const { app } = createConnectedApp({

--- a/tests/app.networkTransition.test.js
+++ b/tests/app.networkTransition.test.js
@@ -10,6 +10,7 @@ const BNB_CHAIN_ID = '0x38';
 function createConnectedApp({
 	currentTab = 'create-order',
 	isCurrentTabVisible = true,
+	walletChainId = POLYGON_CHAIN_ID,
 } = {}) {
 	const AppCtor = window.app.constructor;
 	const app = new AppCtor();
@@ -24,7 +25,7 @@ function createConnectedApp({
 			isWalletConnected: () => true,
 			getSigner: () => ({}),
 		}),
-		getWalletChainId: () => POLYGON_CHAIN_ID,
+		getWalletChainId: () => walletChainId,
 		setWalletChainId: vi.fn(),
 		getWebSocket: () => ({}),
 	};
@@ -96,7 +97,7 @@ describe('App network transition behavior', () => {
 
 		const result = await app.switchWalletToNetwork(targetNetwork, {
 			source: 'write:create the order',
-			selectedChainChanged: false,
+			selectedChainChanged: true,
 		});
 
 		expect(result).toBe(true);
@@ -108,6 +109,80 @@ describe('App network transition behavior', () => {
 		expect(app.refreshActiveComponent).not.toHaveBeenCalled();
 		expect(prepareSpy).toHaveBeenCalledTimes(1);
 		expect(window.location.reload).toHaveBeenCalledTimes(1);
+	});
+
+	it('handles write-triggered wallet-only alignment in place without reloading', async () => {
+		const targetNetwork = getNetworkBySlug('polygon');
+		const { app } = createConnectedApp({
+			walletChainId: BNB_CHAIN_ID,
+		});
+		stubWindowLocationReload();
+		const switchSpy = vi.spyOn(walletManager, 'switchToNetwork').mockImplementation(async () => {
+			walletManager.chainId = POLYGON_CHAIN_ID;
+			return targetNetwork;
+		});
+		const transitionSpy = vi.spyOn(app, 'handleSuccessfulConnectedNetworkTransition').mockResolvedValue(true);
+		const prepareSpy = vi.spyOn(app, 'prepareForNetworkReload');
+
+		const result = await app.switchWalletToNetwork(targetNetwork, {
+			source: 'write:create the order',
+			selectedChainChanged: false,
+		});
+
+		expect(result).toBe(true);
+		expect(switchSpy).toHaveBeenCalledWith(targetNetwork);
+		expect(transitionSpy).toHaveBeenCalledWith(targetNetwork, {
+			source: 'write:create the order',
+			selectedChainChanged: false,
+			walletChainId: POLYGON_CHAIN_ID,
+		});
+		expect(prepareSpy).not.toHaveBeenCalled();
+		expect(window.location.reload).not.toHaveBeenCalled();
+	});
+
+	it('uses in-place alignment on chainChanged for pending wallet-only catch-up', async () => {
+		const targetNetwork = getNetworkBySlug('polygon');
+		const { app } = createConnectedApp({
+			walletChainId: BNB_CHAIN_ID,
+		});
+		stubWindowLocationReload();
+		app.pendingWalletSwitchRequest = {
+			source: 'write:create the order',
+			selectedChainChanged: false,
+			previousSelectedSlug: targetNetwork.slug,
+			targetSlug: targetNetwork.slug,
+		};
+		const transitionSpy = vi.spyOn(app, 'handleSuccessfulConnectedNetworkTransition').mockResolvedValue(true);
+		const prepareSpy = vi.spyOn(app, 'prepareForNetworkReload');
+
+		await app.handleWalletChainChangedEvent(POLYGON_CHAIN_ID);
+
+		expect(app.ctx.setWalletChainId).toHaveBeenCalledWith(POLYGON_CHAIN_ID);
+		expect(transitionSpy).toHaveBeenCalledWith(targetNetwork, {
+			source: 'write:create the order',
+			selectedChainChanged: false,
+			walletChainId: POLYGON_CHAIN_ID,
+		});
+		expect(prepareSpy).not.toHaveBeenCalled();
+		expect(window.location.reload).not.toHaveBeenCalled();
+	});
+
+	it('ignores the duplicate reload when chainChanged arrives after wallet-only alignment', async () => {
+		const targetNetwork = getNetworkBySlug('polygon');
+		const { app } = createConnectedApp({
+			walletChainId: BNB_CHAIN_ID,
+		});
+		stubWindowLocationReload();
+		app.skipNextWalletAlignedReloadTargetSlug = targetNetwork.slug;
+		const transitionSpy = vi.spyOn(app, 'handleSuccessfulConnectedNetworkTransition').mockResolvedValue(true);
+		const prepareSpy = vi.spyOn(app, 'prepareForNetworkReload');
+
+		await app.handleWalletChainChangedEvent(POLYGON_CHAIN_ID);
+
+		expect(transitionSpy).not.toHaveBeenCalled();
+		expect(prepareSpy).not.toHaveBeenCalled();
+		expect(window.location.reload).not.toHaveBeenCalled();
+		expect(app.skipNextWalletAlignedReloadTargetSlug).toBeNull();
 	});
 });
 


### PR DESCRIPTION
## Summary
This changes the write-action network alignment flow so wallet-only catch-up does not force a full page reload.

When the app is already on the selected network and only the connected wallet is behind, write actions now switch the wallet and realign the app in place instead of reloading. Real app-network changes still keep the existing reload behavior.

## Sequence
```mermaid
sequenceDiagram
    participant U as User
    participant C as Create/Fill/Claim
    participant A as App
    participant W as Wallet

    U->>C: Click write action
    C->>A: ensureWalletReadyForWrite()
    A->>W: switchWalletToNetwork(selectedChainChanged=false)
    W-->>A: Wallet switched to selected chain
    A->>A: handleSuccessfulConnectedNetworkTransition()
    A->>A: handleWalletAlignedToSelectedNetwork()
    A-->>C: Continue without reload
```

## Root Cause
Write actions like create, fill, claim, and cancel all go through `ensureWalletReadyForWrite()`. Before this branch, a wallet/network mismatch could consume the first click on a write action by switching the wallet and then refreshing the page, even when the app itself was already on the correct chain.

That caused the transaction not to open on the first attempt and could clear in-progress UI state such as the create-order form.

## What Changed
- Added a dedicated `handleWalletChainChangedEvent(...)` flow in `js/app.js`
- Kept full reloads for real app network changes
- Switched wallet-only write-triggered catch-up to an in-place alignment path
- Cleaned up pending wallet switch state across success and failure paths
- Covered stale cached chain-id, duplicate `chainChanged`, and alignment failure cases in tests

## User Impact
- The first write attempt should no longer be eaten by a wallet-only network switch reload
- Create order / fill / claim / cancel flows stay on the page when only the wallet needs to catch up
- Real header-driven app network changes still reload as before

## Validation
- `npm test -- tests/app.networkTransition.test.js`
- `npm test -- tests/app.headerWalletIndependence.test.js`
