### PR TITLE
Fix #198: highlight low order creation fee balance

### DIFF
--- a/css/components/forms.css
+++ b/css/components/forms.css
@@ -540,6 +540,11 @@
   color: var(--text-secondary, #6b7280);
 }
 
+.fee-balance-value--insufficient {
+  color: #dc2626;
+  font-weight: 600;
+}
+
 .fee-gas {
   font-size: 14px;
   color: #666;

--- a/js/components/CreateOrder.js
+++ b/js/components/CreateOrder.js
@@ -1033,6 +1033,24 @@ export class CreateOrder extends BaseComponent {
         });
     }
 
+    hasInsufficientFeeBalance() {
+        if (!this.feeToken?.amount || !Number.isInteger(this.feeToken?.decimals)) {
+            return false;
+        }
+
+        try {
+            const requiredFeeWei = ethers.BigNumber.from(this.feeToken.amount);
+            const availableBalanceWei = ethers.utils.parseUnits(
+                this.feeToken.balance || '0',
+                this.feeToken.decimals
+            );
+            return availableBalanceWei.lt(requiredFeeWei);
+        } catch (error) {
+            this.debug('Unable to evaluate fee balance sufficiency:', error);
+            return false;
+        }
+    }
+
     formatValidationAmount(amount) {
         const value = String(amount ?? '0').trim() || '0';
         const [wholeRaw = '0', fractionRaw = ''] = value.split('.');
@@ -2896,11 +2914,14 @@ export class CreateOrder extends BaseComponent {
             if (!isWalletConnected || this.isReadOnlyMode) {
                 setVisibility(feeBalance, false);
                 feeBalanceValue.textContent = this.formatFeeTokenBalanceValue(0);
+                feeBalanceValue.classList.remove('fee-balance-value--insufficient');
             } else {
                 const balanceText = this.feeToken.balanceLoading
                     ? 'loading...'
                     : this.formatFeeTokenBalanceValue(this.feeToken.balance);
                 feeBalanceValue.textContent = balanceText;
+                const isInsufficient = !this.feeToken.balanceLoading && this.hasInsufficientFeeBalance();
+                feeBalanceValue.classList.toggle('fee-balance-value--insufficient', isInsufficient);
                 setVisibility(feeBalance, true);
             }
         }

--- a/tests/createOrder.feeDisplay.test.js
+++ b/tests/createOrder.feeDisplay.test.js
@@ -83,6 +83,25 @@ describe('CreateOrder fee display', () => {
             .toBe(`https://polygonscan.com/token/${ethers.utils.getAddress(FEE_TOKEN)}`);
         expect(document.querySelector('.fee-balance')?.classList.contains('is-hidden')).toBe(false);
         expect(document.querySelector('.fee-balance-value')?.textContent).toBe('42.1235');
+        expect(document.querySelector('.fee-balance-value')?.classList.contains('fee-balance-value--insufficient')).toBe(false);
+    });
+
+    it('highlights fee balance in red when balance is below required fee amount', () => {
+        const component = createComponent({ connected: true });
+        component.isReadOnlyMode = false;
+        component.feeToken = {
+            address: FEE_TOKEN,
+            amount: ethers.utils.parseUnits('1', 6),
+            symbol: 'USDC',
+            decimals: 6,
+            balance: '0.5',
+            balanceLoading: false,
+        };
+
+        component.updateFeeDisplay();
+
+        expect(document.querySelector('.fee-balance-value')?.textContent).toBe('0.50');
+        expect(document.querySelector('.fee-balance-value')?.classList.contains('fee-balance-value--insufficient')).toBe(true);
     });
 
     it('refreshes the fee token wallet balance through the connected refresh path', async () => {


### PR DESCRIPTION
## Summary
- highlight the Create Order fee-token balance in red when the connected wallet balance is below the required order creation fee
- evaluate insufficiency using fee-token decimals and fee amount (covers current `< 1 USDC` requirement and future fee changes)
- add a regression test for the low-balance red indicator in the fee display suite

## Testing
- `npx vitest run tests/createOrder.feeDisplay.test.js`
- `npx vitest run`

Fixes #198