### PR TITLE
Fix #195: prevent stale progress session from ignoring first create-order submit

### DIFF
--- a/js/components/CreateOrder.js
+++ b/js/components/CreateOrder.js
@@ -1768,12 +1768,25 @@ export class CreateOrder extends BaseComponent {
         this.orderCreatedSuccessfully = false;
 
         if (this.transactionProgressSession) {
-            if (this.transactionProgressSession.isHidden()) {
-                this.transactionProgressSession.reopen();
+            const existingSession = this.transactionProgressSession;
+            const sessionHidden = existingSession.isHidden();
+            const sessionActive = existingSession.isActive();
+
+            if (sessionHidden) {
+                if (sessionActive) {
+                    existingSession.reopen();
+                    this.updateCreateButtonState();
+                    this.debug('Create order checklist already exists');
+                    return;
+                }
+
+                // Stale hidden terminal checklists should not block the next submit attempt.
+                this.clearTransactionProgressSession();
+            } else {
+                this.updateCreateButtonState();
+                this.debug('Create order checklist already exists');
+                return;
             }
-            this.updateCreateButtonState();
-            this.debug('Create order checklist already exists');
-            return;
         }
 
         if (this.isSubmitting) {

--- a/tests/createOrder.progressSession.test.js
+++ b/tests/createOrder.progressSession.test.js
@@ -103,6 +103,20 @@ describe('CreateOrder checklist session lifecycle', () => {
         expect(component.isSubmitting).toBe(false);
     });
 
+    it('does not reopen a hidden terminal checklist and starts a fresh create flow', async () => {
+        const component = createComponent();
+        const { session } = createSessionDouble({ hidden: true, active: false });
+        component.transactionProgressSession = session;
+        const clearSessionSpy = vi.spyOn(component, 'clearTransactionProgressSession');
+        component.ensureWalletReadyForWrite = vi.fn(async () => false);
+
+        await component.handleCreateOrder({ preventDefault: vi.fn() });
+
+        expect(session.reopen).not.toHaveBeenCalled();
+        expect(clearSessionSpy).toHaveBeenCalledTimes(1);
+        expect(component.refreshContractDisabledState).toHaveBeenCalledTimes(1);
+    });
+
     it('disables the create button while a terminal checklist remains visible', () => {
         const component = createComponent();
         const { session } = createSessionDouble({ hidden: false, active: false });


### PR DESCRIPTION
## Summary
- treat hidden terminal create-order progress sessions as stale and clear them before processing a new submit
- only reopen hidden sessions when they are still active/in-flight
- add regression coverage for the stale hidden terminal checklist path

## Testing
- `npx vitest run tests/createOrder.progressSession.test.js`
- `npx vitest run`

Fixes #195