### PR TITLE
Fix #194: don’t show MetaMask compatibility warning for MetaMask

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -81,7 +81,10 @@ class App {
 
 	async handleWalletConnectEvent(data = {}) {
 		const walletChainId = data?.chainId || walletManager.chainId || null;
-		const shouldShowCompatibilityNotice = data?.userInitiated === true;
+		const isMetaMaskWallet = typeof data?.isMetaMaskWallet === 'boolean'
+			? data.isMetaMaskWallet
+			: walletManager.isConnectedWalletMetaMask();
+		const shouldShowCompatibilityNotice = data?.userInitiated === true && !isMetaMaskWallet;
 
 		clearNetworkSetupRequired();
 		this.ctx.setWalletChainId(walletChainId);

--- a/js/services/WalletManager.js
+++ b/js/services/WalletManager.js
@@ -74,6 +74,19 @@ export class WalletManager {
         };
     }
 
+    isLikelyMetaMaskProvider(provider) {
+        return Boolean(
+            provider?.isMetaMask
+            && !provider?.isBraveWallet
+            && !provider?.isCoinbaseWallet
+            && !provider?.isPhantom
+        );
+    }
+
+    isConnectedWalletMetaMask() {
+        return this.isLikelyMetaMaskProvider(this.getInjectedProvider());
+    }
+
     isRequestCapableInjectedProvider(provider) {
         return typeof provider?.request === 'function';
     }
@@ -340,13 +353,15 @@ export class WalletManager {
             this.notifyListeners('connect', {
                 account: this.account,
                 chainId: this.chainId,
-                userInitiated
+                userInitiated,
+                isMetaMaskWallet: this.isConnectedWalletMetaMask()
             });
 
             return {
                 account: this.account,
                 chainId: this.chainId,
-                userInitiated
+                userInitiated,
+                isMetaMaskWallet: this.isConnectedWalletMetaMask()
             };
         } catch (error) {
             this.debug('Connection error:', error);

--- a/tests/app.walletCompatibilityNotice.test.js
+++ b/tests/app.walletCompatibilityNotice.test.js
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import '../js/app.js';
+import { WALLET_COMPATIBILITY_NOTICE } from '../js/config/index.js';
+import { walletManager } from '../js/services/WalletManager.js';
+
+function createAppHarness() {
+    const AppCtor = window.app.constructor;
+    const app = new AppCtor();
+    app.ctx = {
+        setWalletChainId: vi.fn(),
+    };
+    app.showWarning = vi.fn();
+    app.updateTabVisibility = vi.fn();
+    app.refreshAdminTabVisibility = vi.fn(async () => {});
+    app.refreshClaimTabVisibility = vi.fn(async () => {});
+    app.refreshOrderTabVisibility = vi.fn(async () => {});
+    app.reinitializeComponents = vi.fn(async () => {});
+    return app;
+}
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe('App wallet compatibility notice behavior', () => {
+    it('does not show compatibility warning for user-initiated MetaMask connections', async () => {
+        const app = createAppHarness();
+        vi.spyOn(walletManager, 'isConnectedWalletMetaMask').mockReturnValue(true);
+
+        await app.handleWalletConnectEvent({
+            userInitiated: true,
+            chainId: '0x89',
+            isMetaMaskWallet: true,
+        });
+
+        expect(app.showWarning).not.toHaveBeenCalled();
+    });
+
+    it('shows compatibility warning for user-initiated non-MetaMask connections', async () => {
+        const app = createAppHarness();
+        vi.spyOn(walletManager, 'isConnectedWalletMetaMask').mockReturnValue(false);
+
+        await app.handleWalletConnectEvent({
+            userInitiated: true,
+            chainId: '0x89',
+            isMetaMaskWallet: false,
+        });
+
+        expect(app.showWarning).toHaveBeenCalledWith(WALLET_COMPATIBILITY_NOTICE);
+    });
+});


### PR DESCRIPTION
## Summary
- gate the wallet compatibility warning by connected wallet type
- suppress the warning when the connected wallet is MetaMask
- keep warning behavior for user-initiated non-MetaMask wallet connections
- add tests for both MetaMask and non-MetaMask connection flows

## Testing
- `npx vitest run tests/app.walletCompatibilityNotice.test.js`
- `npx vitest run`

Fixes #194