### PR TITLE
Fix #193: direct Cleanup users to Claim tab for reward withdrawal

### DIFF
--- a/js/components/Cleanup.js
+++ b/js/components/Cleanup.js
@@ -21,6 +21,20 @@ export class Cleanup extends BaseComponent {
         this.warn = logger.warn.bind(logger);
     }
 
+    scheduleClaimVisibilityRefreshAfterCleanup() {
+        const app = window.app;
+        if (typeof app?.scheduleClaimTabVisibilityRefresh === 'function') {
+            app.scheduleClaimTabVisibilityRefresh(null, { force: true });
+            return;
+        }
+
+        if (typeof app?.refreshClaimTabVisibility === 'function') {
+            app.refreshClaimTabVisibility({ force: true }).catch((error) => {
+                this.debug('Fallback claim-tab visibility refresh failed after cleanup:', error);
+            });
+        }
+    }
+
     async initialize(readOnlyMode = true) {
         if (this.isInitializing) {
             this.debug('Already initializing, skipping...');
@@ -72,7 +86,8 @@ export class Cleanup extends BaseComponent {
                     <div class="cleanup-section">
                         <h2>Cleanup Expired Orders</h2>
                         <div class="cleanup-info">
-                            <p>Help maintain the orderbook by cleaning up expired orders</p>
+                            <p>Help maintain the orderbook by cleaning up expired orders.</p>
+                            <p>Cleanup rewards are credited to your Claim balance. Go to the Claim tab to withdraw.</p>
                             <div class="cleanup-stats">
                                 <div class="cleanup-rewards">
                                     <h3>Cleanup Information</h3>
@@ -143,7 +158,8 @@ export class Cleanup extends BaseComponent {
                 <div class="cleanup-section">
                     <h2>Cleanup Expired Orders</h2>
                     <div class="cleanup-info">
-                        <p>Help maintain the orderbook by cleaning up expired orders</p>
+                        <p>Help maintain the orderbook by cleaning up expired orders.</p>
+                        <p>Cleanup rewards are credited to your Claim balance. Go to the Claim tab to withdraw.</p>
                         <div class="cleanup-stats">
                             <div class="cleanup-rewards">
                                 <h3>Cleanup Information</h3>
@@ -567,11 +583,17 @@ export class Cleanup extends BaseComponent {
                     ethers.utils.formatUnits(userFeeEvent.amount, tokenInfo.decimals)
                 ).toFixed(6);
                 
-                this.showSuccess(`Cleanup successful! You received ${formattedAmount} ${tokenInfo.symbol} as reward.`);
+                this.showSuccess(
+                    `Cleanup successful! Reward added to your Claim balance: ${formattedAmount} ${tokenInfo.symbol}. ` +
+                    'Go to the Claim tab to withdraw.'
+                );
             } catch (error) {
                 this.debug('Error formatting fee amount:', error);
-                this.showSuccess('Cleanup successful! You received a reward. Check your wallet.');
+                this.showSuccess(
+                    'Cleanup successful! Reward added to your Claim balance. Go to the Claim tab to withdraw.'
+                );
             }
+            this.scheduleClaimVisibilityRefreshAfterCleanup();
         } else if (cleanedEvents.length > 0 && feeEvents.length === 0) {
             // Order was cleaned but no fees were distributed
             const cleanedMsg = cleanedEvents.map(c => `#${c.orderId}`).join(', ');
@@ -585,7 +607,7 @@ export class Cleanup extends BaseComponent {
                 msg += `${cleanedEvents.length} order(s) cleaned. `;
             }
             if (feeEvents.length > 0) {
-                msg += `Fees distributed to ${feeEvents.length} recipient(s).`;
+                msg += `Fees credited to Claim balances for ${feeEvents.length} recipient(s).`;
             }
             this.showSuccess(msg);
         }

--- a/tests/cleanup.claimMessaging.test.js
+++ b/tests/cleanup.claimMessaging.test.js
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Cleanup } from '../js/components/Cleanup.js';
+
+describe('Cleanup claim-directed messaging', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+        delete window.app;
+        document.body.innerHTML = '';
+    });
+
+    it('directs users to Claim tab when cleanup reward is credited', async () => {
+        document.body.innerHTML = '<div id="cleanup-container"></div>';
+        const component = new Cleanup();
+        component.webSocket = {
+            getTokenInfo: vi.fn(async () => ({
+                symbol: 'USDC',
+                decimals: 6,
+            })),
+            removeOrders: vi.fn(),
+        };
+        component.showSuccess = vi.fn();
+        component.showInfo = vi.fn();
+        component.debug = vi.fn();
+
+        const scheduleClaimTabVisibilityRefresh = vi.fn();
+        window.app = { scheduleClaimTabVisibilityRefresh };
+
+        await component.handleCleanupResult({
+            feeEvents: [
+                {
+                    recipient: '0x1111111111111111111111111111111111111111',
+                    feeToken: '0x2222222222222222222222222222222222222222',
+                    amount: '1000000',
+                },
+            ],
+            cleanedEvents: [
+                { orderId: '7' },
+            ],
+            userAddress: '0x1111111111111111111111111111111111111111',
+        });
+
+        expect(component.showSuccess).toHaveBeenCalledTimes(1);
+        const successMessage = component.showSuccess.mock.calls[0][0];
+        expect(successMessage).toContain('Reward added to your Claim balance');
+        expect(successMessage).toContain('Go to the Claim tab to withdraw');
+        expect(successMessage.toLowerCase()).not.toContain('check your wallet');
+        expect(scheduleClaimTabVisibilityRefresh).toHaveBeenCalledWith(null, { force: true });
+    });
+});


### PR DESCRIPTION
## Summary
- update Cleanup tab helper copy to explain that cleanup rewards are credited to Claim balance and must be withdrawn from Claim tab
- update cleanup success messages to remove misleading "you received" / "check your wallet" wording for claim-credit flow
- trigger immediate claim-tab visibility refresh after cleanup reward credit so the Claim path becomes available right away
- add regression test coverage for claim-directed cleanup messaging

## Testing
- `npx vitest run tests/cleanup.claimMessaging.test.js`
- `npx vitest run`

Fixes #193