### PR TITLE
Disable header network switching during in-flight wallet actions

### DIFF
--- a/css/components/wallet.css
+++ b/css/components/wallet.css
@@ -30,6 +30,17 @@
   background: var(--background-hover);
 }
 
+.network-button.wallet-action-pending,
+.network-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.network-button.wallet-action-pending:hover,
+.network-button:disabled:hover {
+  background: var(--background-secondary);
+}
+
 .network-button[data-network-status="connected"] {
   background: var(--network-button-connected-bg);
   border-color: var(--network-button-connected-border);
@@ -105,6 +116,11 @@
 
 .network-dropdown.hidden {
   display: none;
+}
+
+.network-dropdown.wallet-action-pending {
+  pointer-events: none;
+  opacity: 0.7;
 }
 
 .network-option {

--- a/js/app.js
+++ b/js/app.js
@@ -1240,6 +1240,10 @@ class App {
 
 	async handleNetworkSelectionCommit(network, options = {}) {
 		if (!network) return;
+		if (isNetworkSelectorLockedByWalletAction()) {
+			this.showWarning(NETWORK_SELECTOR_LOCK_WARNING);
+			return false;
+		}
 
 		const {
 			selectedChainChanged = true,
@@ -1479,6 +1483,10 @@ class App {
 						} catch (error) {
 							console.error('[App] Error handling chainChanged:', error);
 						}
+						break;
+					}
+					case 'walletActionStateChanged': {
+						syncNetworkSelectorWalletActionState();
 						break;
 					}
 				}
@@ -2132,6 +2140,7 @@ let addNetworkButton, networkButton, networkDropdown, networkBadge;
 let networkSelectorElement;
 let selectedNetworkSlug = null;
 let networkSetupRequiredSlug = null;
+const NETWORK_SELECTOR_LOCK_WARNING = 'Finish or cancel the current wallet action before switching networks.';
 
 function getNetworkLogoPath(network) {
 	return typeof network?.logo === 'string' ? network.logo : '';
@@ -2249,6 +2258,29 @@ function syncAddNetworkButtonVisibility() {
 		: 'Add Network';
 }
 
+function isNetworkSelectorLockedByWalletAction() {
+	return Boolean(walletManager.isWalletActionPending?.());
+}
+
+function syncNetworkSelectorWalletActionState() {
+	const isLocked = isNetworkSelectorLockedByWalletAction();
+
+	if (networkButton) {
+		networkButton.disabled = isLocked;
+		networkButton.setAttribute('aria-disabled', String(isLocked));
+		networkButton.classList.toggle('wallet-action-pending', isLocked);
+	}
+
+	if (networkDropdown) {
+		networkDropdown.dataset.walletActionPending = String(isLocked);
+		networkDropdown.classList.toggle('wallet-action-pending', isLocked);
+	}
+
+	if (isLocked) {
+		toggleNetworkDropdown(false);
+	}
+}
+
 function triggerPageReloadWithSwitchFallback(options = {}) {
 	try {
 		window.app?.prepareForNetworkReload?.(options);
@@ -2283,6 +2315,7 @@ function syncNetworkBadgeFromState() {
 	if (networkDropdown) {
 		networkDropdown.dataset.networkStatus = 'default';
 	}
+	syncNetworkSelectorWalletActionState();
 
 	// Let syncAddNetworkButtonVisibility() decide visibility based on networkSetupRequiredSlug (PR #178 review)
 	// This preserves the "Add <Network>" retry affordance when setup is required
@@ -2345,6 +2378,11 @@ const populateNetworkOptions = () => {
 	// Re-attach click handlers only if multiple networks.
 		document.querySelectorAll('.network-option').forEach(option => {
 			const commitSelection = async () => {
+				if (isNetworkSelectorLockedByWalletAction()) {
+					window.app?.showWarning?.(NETWORK_SELECTOR_LOCK_WARNING);
+					return;
+				}
+
 				const network = getNetworkBySlug(option.dataset.slug);
 				if (!network) return;
 				const previousSelectedNetwork = getNetworkBySlug(
@@ -2377,6 +2415,7 @@ const populateNetworkOptions = () => {
 	});
 
 	applySelectedNetwork(getInitialSelectedNetwork(), { updateUrl: true });
+	syncNetworkSelectorWalletActionState();
 };
 
 // Initialize network dropdown when DOM is ready
@@ -2425,6 +2464,10 @@ document.addEventListener('DOMContentLoaded', () => {
 		networkButton.addEventListener('click', (event) => {
 			event.preventDefault();
 			if (networkButton.classList.contains('single-network')) return;
+			if (isNetworkSelectorLockedByWalletAction()) {
+				window.app?.showWarning?.(NETWORK_SELECTOR_LOCK_WARNING);
+				return;
+			}
 			toggleNetworkDropdown();
 		});
 	}

--- a/js/services/WalletManager.js
+++ b/js/services/WalletManager.js
@@ -28,6 +28,17 @@ const normalizeChainId = (chainId) => {
 };
 
 const STARTUP_REQUEST_TIMEOUT_MS = 4000;
+const INTERACTIVE_WALLET_METHODS = new Set([
+    'eth_requestaccounts',
+    'wallet_switchethereumchain',
+    'wallet_addethereumchain',
+    'eth_sendtransaction',
+    'eth_signtypeddata',
+    'eth_signtypeddata_v3',
+    'eth_signtypeddata_v4',
+    'eth_sign',
+    'personal_sign',
+]);
 
 export class WalletManager {
     constructor() {
@@ -62,6 +73,7 @@ export class WalletManager {
         // Add user preference tracking for disconnect state
         this.userDisconnected = false;
         this.STORAGE_KEY = 'wallet_user_disconnected';
+        this.walletActionPendingCount = 0;
     }
 
     describeProvider(provider, index = null) {
@@ -132,6 +144,50 @@ export class WalletManager {
         return !!this.getInjectedProvider();
     }
 
+    instrumentInjectedProviderRequest(provider) {
+        if (!provider || provider.__whaleSwapWalletActionPatched || typeof provider.request !== 'function') {
+            return provider;
+        }
+
+        const originalRequest = provider.request.bind(provider);
+        provider.__whaleSwapWalletActionPatched = true;
+
+        provider.request = async (payload) => {
+            const method = String(payload?.method || '').toLowerCase();
+            const isInteractiveMethod = INTERACTIVE_WALLET_METHODS.has(method);
+
+            if (isInteractiveMethod) {
+                this.walletActionPendingCount += 1;
+                this.notifyListeners('walletActionStateChanged', {
+                    pending: true,
+                    method,
+                    pendingCount: this.walletActionPendingCount,
+                });
+            }
+
+            try {
+                return await originalRequest(payload);
+            } finally {
+                if (!isInteractiveMethod) {
+                    return;
+                }
+
+                this.walletActionPendingCount = Math.max(0, this.walletActionPendingCount - 1);
+                this.notifyListeners('walletActionStateChanged', {
+                    pending: this.walletActionPendingCount > 0,
+                    method,
+                    pendingCount: this.walletActionPendingCount,
+                });
+            }
+        };
+
+        return provider;
+    }
+
+    isWalletActionPending() {
+        return this.walletActionPendingCount > 0;
+    }
+
     async request(method, params = undefined) {
         const injectedProvider = this.getInjectedProvider();
         if (!injectedProvider?.request) {
@@ -185,6 +241,8 @@ export class WalletManager {
                 this.isInitialized = true;
                 return;
             }
+
+            this.instrumentInjectedProviderRequest(injectedProvider);
 
             // Use the "any" network so the provider survives chain changes without
             // throwing "underlying network changed" on the next signer/contract call.

--- a/tests/app.headerWalletIndependence.test.js
+++ b/tests/app.headerWalletIndependence.test.js
@@ -167,6 +167,42 @@ describe('Header wallet connection independence (issue #153)', () => {
 			// Should NOT have 'disconnected' class
 			expect(networkBadge?.classList.contains('disconnected')).toBe(false);
 		});
+
+		it('disables the header network selector while a wallet action is pending', () => {
+			const isPendingSpy = vi.spyOn(walletManager, 'isWalletActionPending').mockReturnValue(true);
+			initializeApp({
+				walletChainId: BNB_CHAIN_ID,
+				selectedSlug: POLYGON_SLUG,
+			});
+
+			window.syncNetworkBadgeFromState?.();
+
+			const networkButton = document.querySelector('.network-button');
+			const networkDropdown = document.querySelector('.network-dropdown');
+			expect(networkButton?.disabled).toBe(true);
+			expect(networkButton?.classList.contains('wallet-action-pending')).toBe(true);
+			expect(networkDropdown?.dataset.walletActionPending).toBe('true');
+
+			isPendingSpy.mockRestore();
+		});
+
+		it('re-enables the header network selector after wallet action completes', () => {
+			const isPendingSpy = vi.spyOn(walletManager, 'isWalletActionPending').mockReturnValue(false);
+			initializeApp({
+				walletChainId: BNB_CHAIN_ID,
+				selectedSlug: POLYGON_SLUG,
+			});
+
+			window.syncNetworkBadgeFromState?.();
+
+			const networkButton = document.querySelector('.network-button');
+			const networkDropdown = document.querySelector('.network-dropdown');
+			expect(networkButton?.disabled).toBe(false);
+			expect(networkButton?.classList.contains('wallet-action-pending')).toBe(false);
+			expect(networkDropdown?.dataset.walletActionPending).toBe('false');
+
+			isPendingSpy.mockRestore();
+		});
 	});
 
 	describe('handleNetworkSelectionCommit', () => {
@@ -259,6 +295,27 @@ describe('Header wallet connection independence (issue #153)', () => {
 			await app.handleNetworkSelectionCommit(null);
 
 			expect(window.location.reload).not.toHaveBeenCalled();
+		});
+
+		it('blocks network switching while wallet action is pending', async () => {
+			const isPendingSpy = vi.spyOn(walletManager, 'isWalletActionPending').mockReturnValue(true);
+			const app = initializeApp({
+				walletChainId: BNB_CHAIN_ID,
+				selectedSlug: ETHEREUM_SLUG,
+			});
+			const switchSpy = vi.spyOn(app, 'switchWalletToNetwork');
+			const targetNetwork = getNetworkBySlug(POLYGON_SLUG);
+
+			await app.handleNetworkSelectionCommit(targetNetwork, {
+				selectedChainChanged: true,
+				previousSelectedNetwork: getNetworkBySlug(ETHEREUM_SLUG),
+			});
+
+			expect(switchSpy).not.toHaveBeenCalled();
+			expect(app.showWarning).toHaveBeenCalledWith('Finish or cancel the current wallet action before switching networks.');
+			expect(window.location.reload).not.toHaveBeenCalled();
+
+			isPendingSpy.mockRestore();
 		});
 	});
 


### PR DESCRIPTION
## Summary\n- disable the header network selector while interactive wallet actions are pending\n- block network switch attempts during pending wallet actions and show a clear warning\n- re-enable selector state automatically when the wallet action resolves/rejects\n- add regression tests for disable/block/re-enable behavior\n\n## Validation\n- npx vitest run tests/app.headerWalletIndependence.test.js\n- npx vitest run\n\nFixes #203