### PR TITLE
Optimize wallet-only network catch-up reconciliation

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1050,31 +1050,15 @@ class App {
 		const {
 			walletChainId = null,
 		} = options;
-		const preferredTab = this.currentTab;
-		const wallet = this.ctx?.getWallet?.();
 
 		this.debug('Handling wallet alignment on already-selected network:', {
 			targetNetwork: targetNetwork.slug,
-			preferredTab,
 		});
 
 		this.ctx?.setWalletChainId?.(walletChainId ?? walletManager.chainId ?? targetNetwork.chainId);
 		clearNetworkSetupRequired();
 		setActiveNetwork(targetNetwork);
 		syncNetworkBadgeFromState();
-
-		this.updateTabVisibility(true);
-		await this.refreshAdminTabVisibility();
-		await this.refreshClaimTabVisibility({ force: true });
-		await this.refreshOrderTabVisibility({ force: true });
-
-		await this.refreshActiveComponent();
-
-		if (!this.isTabVisible(preferredTab)) {
-			await this.showTab('create-order', !wallet?.isWalletConnected?.(), {
-				skipInitialize: this.tabReady.has('create-order'),
-			});
-		}
 
 		return true;
 	}

--- a/tests/app.networkTransition.test.js
+++ b/tests/app.networkTransition.test.js
@@ -259,6 +259,31 @@ describe('App network transition behavior', () => {
 		expect(failureSpy).not.toHaveBeenCalled();
 		expect(app.pendingWalletSwitchRequest).toBeNull();
 	});
+
+	it('skips heavy UI refresh work for wallet-only alignment on the already-selected network', async () => {
+		const targetNetwork = getNetworkBySlug('polygon');
+		setActiveNetwork(targetNetwork);
+		const { app } = createConnectedApp({
+			walletChainId: BNB_CHAIN_ID,
+		});
+
+		const result = await app.handleSuccessfulConnectedNetworkTransition(targetNetwork, {
+			source: 'write:create the order',
+			selectedChainChanged: false,
+			walletChainId: POLYGON_CHAIN_ID,
+		});
+
+		expect(result).toBe(true);
+		expect(app.ctx.setWalletChainId).toHaveBeenCalledWith(POLYGON_CHAIN_ID);
+		expect(app.recreateNetworkServices).not.toHaveBeenCalled();
+		expect(app.reinitializeComponents).not.toHaveBeenCalled();
+		expect(app.updateTabVisibility).not.toHaveBeenCalled();
+		expect(app.refreshAdminTabVisibility).not.toHaveBeenCalled();
+		expect(app.refreshClaimTabVisibility).not.toHaveBeenCalled();
+		expect(app.refreshOrderTabVisibility).not.toHaveBeenCalled();
+		expect(app.refreshActiveComponent).not.toHaveBeenCalled();
+		expect(app.showTab).not.toHaveBeenCalled();
+	});
 });
 
 describe('App active tab persistence', () => {


### PR DESCRIPTION
## Summary\n- trim the wallet-only alignment path when the selected app network is already correct\n- keep state updates limited to wallet chain state plus selected-network badge sync\n- avoid unnecessary in-place refresh work (admin/claim/order visibility refreshes, active component refresh, tab reshuffling) for selectedChainChanged=false\n- add regression coverage to lock in the minimized path\n\n## Validation\n- npx vitest run tests/app.networkTransition.test.js\n- npx vitest run\n\nFixes #201