### PR TITLE
Fix cleanup startup retry mode race on wallet connect

### DIFF
--- a/js/components/Cleanup.js
+++ b/js/components/Cleanup.js
@@ -13,6 +13,7 @@ export class Cleanup extends BaseComponent {
         this.currentMode = null; // track readOnly/connected mode to allow re-init on change
         this.eventSubscriptions = new Set(); // Track WebSocket subscriptions for cleanup
         this.initializationRetryTimer = null;
+        this.initializationRetryMode = null;
         
         // Initialize logger
         const logger = createLogger('CLEANUP');
@@ -228,12 +229,21 @@ export class Cleanup extends BaseComponent {
 
     scheduleInitializationRetry(readOnlyMode) {
         if (this.initializationRetryTimer) {
-            return;
+            if (this.initializationRetryMode === readOnlyMode) {
+                return;
+            }
+
+            clearTimeout(this.initializationRetryTimer);
+            this.initializationRetryTimer = null;
+            this.initializationRetryMode = null;
         }
 
+        this.initializationRetryMode = readOnlyMode;
         this.initializationRetryTimer = setTimeout(() => {
             this.initializationRetryTimer = null;
-            this.initialize(readOnlyMode).catch((error) => {
+            const retryMode = this.initializationRetryMode;
+            this.initializationRetryMode = null;
+            this.initialize(retryMode).catch((error) => {
                 this.debug('Deferred Cleanup initialization retry failed:', error);
             });
         }, 300);
@@ -696,6 +706,7 @@ export class Cleanup extends BaseComponent {
             clearTimeout(this.initializationRetryTimer);
             this.initializationRetryTimer = null;
         }
+        this.initializationRetryMode = null;
         
         // Unsubscribe from WebSocket events
         if (this.eventSubscriptions && this.eventSubscriptions.size > 0) {

--- a/tests/component.wsRecovery.test.js
+++ b/tests/component.wsRecovery.test.js
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import '../js/app.js';
 import { Cleanup } from '../js/components/Cleanup.js';
 import { ContractParams } from '../js/components/ContractParams.js';
 
@@ -68,6 +69,57 @@ describe('WS recovery behavior', () => {
         expect(initSpy).toHaveBeenCalledWith(false);
         expect(component.initializationRetryTimer).toBeNull();
         expect(component.initializationRetryMode).toBeNull();
+    });
+
+    it('App reinitializeComponents replaces Cleanup pending retry mode during wallet connect', async () => {
+        vi.useFakeTimers();
+        document.body.innerHTML = '<div id="cleanup-container"></div>';
+
+        const ws = { contract: null };
+        const cleanupComponent = new Cleanup();
+        cleanupComponent.setContext(createBaseContext({ ws }));
+
+        await cleanupComponent.initialize(true);
+        const firstRetryTimer = cleanupComponent.initializationRetryTimer;
+        expect(firstRetryTimer).toBeTruthy();
+        expect(cleanupComponent.initializationRetryMode).toBe(true);
+
+        const AppCtor = window.app.constructor;
+        const app = new AppCtor();
+        app.currentTab = 'cleanup-orders';
+        app.tabReady = new Set();
+        app.showTab = vi.fn(async () => {});
+        app.components = {
+            'create-order': {
+                resetState: vi.fn(),
+                initialize: vi.fn(async () => {}),
+            },
+            'cleanup-orders': cleanupComponent,
+        };
+        app.ctx = {
+            getWallet: () => ({
+                isWalletConnected: () => true,
+            }),
+            getWebSocket: () => ({
+                orderCache: new Map(),
+                waitForInitialization: vi.fn(async () => true),
+                syncAllOrders: vi.fn(async () => {}),
+            }),
+        };
+
+        await app.reinitializeComponents({ preserveOrders: true });
+
+        const secondRetryTimer = cleanupComponent.initializationRetryTimer;
+        expect(secondRetryTimer).toBeTruthy();
+        expect(secondRetryTimer).not.toBe(firstRetryTimer);
+        expect(cleanupComponent.initializationRetryMode).toBe(false);
+
+        const retryInitSpy = vi.spyOn(cleanupComponent, 'initialize').mockResolvedValue();
+        vi.advanceTimersByTime(300);
+        expect(retryInitSpy).toHaveBeenCalledTimes(1);
+        expect(retryInitSpy).toHaveBeenCalledWith(false);
+        expect(cleanupComponent.initializationRetryTimer).toBeNull();
+        expect(cleanupComponent.initializationRetryMode).toBeNull();
     });
 
     it('ContractParams recovery waits for initialization when websocket is not initialized yet', async () => {

--- a/tests/component.wsRecovery.test.js
+++ b/tests/component.wsRecovery.test.js
@@ -46,6 +46,30 @@ describe('WS recovery behavior', () => {
         expect(component.initializationRetryTimer).toBeNull();
     });
 
+    it('Cleanup replaces a pending retry when mode changes before timer fires', () => {
+        vi.useFakeTimers();
+        document.body.innerHTML = '<div id="cleanup-container"></div>';
+
+        const component = new Cleanup();
+        const initSpy = vi.spyOn(component, 'initialize').mockResolvedValue();
+
+        component.scheduleInitializationRetry(true);
+        const firstRetryTimer = component.initializationRetryTimer;
+        expect(component.initializationRetryMode).toBe(true);
+
+        component.scheduleInitializationRetry(false);
+        const secondRetryTimer = component.initializationRetryTimer;
+        expect(secondRetryTimer).toBeTruthy();
+        expect(secondRetryTimer).not.toBe(firstRetryTimer);
+        expect(component.initializationRetryMode).toBe(false);
+
+        vi.advanceTimersByTime(300);
+        expect(initSpy).toHaveBeenCalledTimes(1);
+        expect(initSpy).toHaveBeenCalledWith(false);
+        expect(component.initializationRetryTimer).toBeNull();
+        expect(component.initializationRetryMode).toBeNull();
+    });
+
     it('ContractParams recovery waits for initialization when websocket is not initialized yet', async () => {
         document.body.innerHTML = '<div id="contract-params"></div>';
 


### PR DESCRIPTION
## Summary\n- fix Cleanup deferred initialization retry so pending retries are mode-aware\n- when retry mode changes (read-only to connected), replace stale pending timer instead of keeping the old one\n- clear tracked retry mode on cleanup and after retry dispatch\n- add regression coverage for mode-switch before deferred retry fires\n\n## Validation\n- npx vitest run tests/component.wsRecovery.test.js\n- npx vitest run\n\nFixes #190