### PR TITLE
Issue #203: lock header network selector via shared wallet-action state

### DIFF
--- a/css/components/wallet.css
+++ b/css/components/wallet.css
@@ -30,6 +30,17 @@
   background: var(--background-hover);
 }
 
+.network-button.wallet-action-pending,
+.network-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.network-button.wallet-action-pending:hover,
+.network-button:disabled:hover {
+  background: var(--background-secondary);
+}
+
 .network-button[data-network-status="connected"] {
   background: var(--network-button-connected-bg);
   border-color: var(--network-button-connected-border);
@@ -105,6 +116,11 @@
 
 .network-dropdown.hidden {
   display: none;
+}
+
+.network-dropdown.wallet-action-pending {
+  pointer-events: none;
+  opacity: 0.7;
 }
 
 .network-option {

--- a/js/app.js
+++ b/js/app.js
@@ -1227,6 +1227,10 @@ class App {
 
 	async handleNetworkSelectionCommit(network, options = {}) {
 		if (!network) return;
+		if (isNetworkSelectorLockedByWalletAction()) {
+			this.showWarning(NETWORK_SELECTOR_LOCK_WARNING);
+			return false;
+		}
 
 		const {
 			selectedChainChanged = true,
@@ -2119,6 +2123,7 @@ let addNetworkButton, networkButton, networkDropdown, networkBadge;
 let networkSelectorElement;
 let selectedNetworkSlug = null;
 let networkSetupRequiredSlug = null;
+const NETWORK_SELECTOR_LOCK_WARNING = 'Finish or cancel the current wallet action before switching networks.';
 
 function getNetworkLogoPath(network) {
 	return typeof network?.logo === 'string' ? network.logo : '';
@@ -2236,6 +2241,29 @@ function syncAddNetworkButtonVisibility() {
 		: 'Add Network';
 }
 
+function isNetworkSelectorLockedByWalletAction() {
+	return Boolean(window.app?.ctx?.isWalletActionInFlight?.());
+}
+
+function syncNetworkSelectorWalletActionState() {
+	const isLocked = isNetworkSelectorLockedByWalletAction();
+
+	if (networkButton) {
+		networkButton.disabled = isLocked;
+		networkButton.setAttribute('aria-disabled', String(isLocked));
+		networkButton.classList.toggle('wallet-action-pending', isLocked);
+	}
+
+	if (networkDropdown) {
+		networkDropdown.dataset.walletActionPending = String(isLocked);
+		networkDropdown.classList.toggle('wallet-action-pending', isLocked);
+	}
+
+	if (isLocked) {
+		toggleNetworkDropdown(false);
+	}
+}
+
 function triggerPageReloadWithSwitchFallback(options = {}) {
 	try {
 		window.app?.prepareForNetworkReload?.(options);
@@ -2270,6 +2298,7 @@ function syncNetworkBadgeFromState() {
 	if (networkDropdown) {
 		networkDropdown.dataset.networkStatus = 'default';
 	}
+	syncNetworkSelectorWalletActionState();
 
 	// Let syncAddNetworkButtonVisibility() decide visibility based on networkSetupRequiredSlug (PR #178 review)
 	// This preserves the "Add <Network>" retry affordance when setup is required
@@ -2332,6 +2361,11 @@ const populateNetworkOptions = () => {
 	// Re-attach click handlers only if multiple networks.
 		document.querySelectorAll('.network-option').forEach(option => {
 			const commitSelection = async () => {
+				if (isNetworkSelectorLockedByWalletAction()) {
+					window.app?.showWarning?.(NETWORK_SELECTOR_LOCK_WARNING);
+					return;
+				}
+
 				const network = getNetworkBySlug(option.dataset.slug);
 				if (!network) return;
 				const previousSelectedNetwork = getNetworkBySlug(
@@ -2364,6 +2398,7 @@ const populateNetworkOptions = () => {
 	});
 
 	applySelectedNetwork(getInitialSelectedNetwork(), { updateUrl: true });
+	syncNetworkSelectorWalletActionState();
 };
 
 // Initialize network dropdown when DOM is ready
@@ -2412,6 +2447,10 @@ document.addEventListener('DOMContentLoaded', () => {
 		networkButton.addEventListener('click', (event) => {
 			event.preventDefault();
 			if (networkButton.classList.contains('single-network')) return;
+			if (isNetworkSelectorLockedByWalletAction()) {
+				window.app?.showWarning?.(NETWORK_SELECTOR_LOCK_WARNING);
+				return;
+			}
 			toggleNetworkDropdown();
 		});
 	}
@@ -2435,6 +2474,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
 	window.addEventListener('popstate', () => {
 		applySelectedNetwork(getInitialSelectedNetwork(), { updateUrl: false });
+	});
+	window.addEventListener('wallet-action-lock-changed', () => {
+		syncNetworkSelectorWalletActionState();
 	});
 
 	window.syncNetworkBadgeFromState = syncNetworkBadgeFromState;

--- a/js/services/AppContext.js
+++ b/js/services/AppContext.js
@@ -39,6 +39,16 @@ function assert(condition, message) {
     }
 }
 
+function emitWalletActionStateChange(isActive) {
+    if (typeof window === 'undefined' || typeof window.dispatchEvent !== 'function') {
+        return;
+    }
+
+    window.dispatchEvent(new CustomEvent('wallet-action-lock-changed', {
+        detail: { isActive: !!isActive }
+    }));
+}
+
 export function createAppContext() {
     return {
         // Core services (set by App during load)
@@ -126,11 +136,13 @@ export function createAppContext() {
         beginWalletAction() {
             assert(!this.isWalletActionActive, 'Wallet action already active');
             this.isWalletActionActive = true;
+            emitWalletActionStateChange(true);
         },
 
         endWalletAction() {
             assert(this.isWalletActionActive, 'Wallet action not active');
             this.isWalletActionActive = false;
+            emitWalletActionStateChange(false);
         },
 
         isWalletActionInFlight() {

--- a/tests/app.headerWalletIndependence.test.js
+++ b/tests/app.headerWalletIndependence.test.js
@@ -32,6 +32,7 @@ function setupNetworkSelectorDom() {
 
 function initializeApp({ walletChainId, selectedSlug }) {
 	setupNetworkSelectorDom();
+	let walletActionInFlight = false;
 
 	const selectedNetwork = getNetworkBySlug(selectedSlug);
 	if (!selectedNetwork) {
@@ -55,10 +56,14 @@ function initializeApp({ walletChainId, selectedSlug }) {
 	app.ctx = {
 		getSelectedChainSlug: () => selectedSlug,
 		getWalletChainId: () => walletChainId,
+		isWalletActionInFlight: () => walletActionInFlight,
 		getWallet: () => ({
 			isWalletConnected: () => !!walletChainId,
 			getSigner: () => walletChainId ? {} : null,
 		}),
+	};
+	app.__setWalletActionInFlight = (value) => {
+		walletActionInFlight = !!value;
 	};
 	app.showWarning = vi.fn();
 	app.warn = vi.fn();
@@ -168,6 +173,44 @@ describe('Header wallet connection independence (issue #153)', () => {
 			// Should NOT have 'disconnected' class
 			expect(networkBadge?.classList.contains('disconnected')).toBe(false);
 		});
+
+		it('disables the header network selector while a wallet action is in flight', () => {
+			const app = initializeApp({
+				walletChainId: BNB_CHAIN_ID,
+				selectedSlug: POLYGON_SLUG,
+			});
+			app.__setWalletActionInFlight(true);
+			window.dispatchEvent(new CustomEvent('wallet-action-lock-changed', {
+				detail: { isActive: true },
+			}));
+
+			const networkButton = document.querySelector('.network-button');
+			const networkDropdown = document.querySelector('.network-dropdown');
+			expect(networkButton?.disabled).toBe(true);
+			expect(networkButton?.classList.contains('wallet-action-pending')).toBe(true);
+			expect(networkDropdown?.dataset.walletActionPending).toBe('true');
+		});
+
+		it('re-enables the header network selector when wallet action lock clears', () => {
+			const app = initializeApp({
+				walletChainId: BNB_CHAIN_ID,
+				selectedSlug: POLYGON_SLUG,
+			});
+			app.__setWalletActionInFlight(true);
+			window.dispatchEvent(new CustomEvent('wallet-action-lock-changed', {
+				detail: { isActive: true },
+			}));
+			app.__setWalletActionInFlight(false);
+			window.dispatchEvent(new CustomEvent('wallet-action-lock-changed', {
+				detail: { isActive: false },
+			}));
+
+			const networkButton = document.querySelector('.network-button');
+			const networkDropdown = document.querySelector('.network-dropdown');
+			expect(networkButton?.disabled).toBe(false);
+			expect(networkButton?.classList.contains('wallet-action-pending')).toBe(false);
+			expect(networkDropdown?.dataset.walletActionPending).toBe('false');
+		});
 	});
 
 	describe('handleNetworkSelectionCommit', () => {
@@ -259,6 +302,25 @@ describe('Header wallet connection independence (issue #153)', () => {
 
 			await app.handleNetworkSelectionCommit(null);
 
+			expect(window.location.reload).not.toHaveBeenCalled();
+		});
+
+		it('blocks network switching while wallet action is in flight', async () => {
+			const app = initializeApp({
+				walletChainId: BNB_CHAIN_ID,
+				selectedSlug: ETHEREUM_SLUG,
+			});
+			app.__setWalletActionInFlight(true);
+			const targetNetwork = getNetworkBySlug(POLYGON_SLUG);
+			const switchSpy = vi.spyOn(app, 'switchWalletToNetwork');
+
+			await app.handleNetworkSelectionCommit(targetNetwork, {
+				selectedChainChanged: true,
+				previousSelectedNetwork: getNetworkBySlug(ETHEREUM_SLUG),
+			});
+
+			expect(switchSpy).not.toHaveBeenCalled();
+			expect(app.showWarning).toHaveBeenCalledWith('Finish or cancel the current wallet action before switching networks.');
 			expect(window.location.reload).not.toHaveBeenCalled();
 		});
 	});


### PR DESCRIPTION
Summary:
re-implements issue #203 on top of PR #213 shared wallet-action lock instead of provider request instrumentation

header network selector now reads shared wallet-action state from app context\n- blocks selector open and network commit while wallet action lock is active.

adds visual disabled state and warning toast when blocked

re-enables automatically via shared lock state-change event from AppContext

Implementation notes\n- AppContext begin/end wallet action now dispatch wallet-action-lock-changed

 app header listens for that event and syncs selector disabled state

guard remains in handleNetworkSelectionCommit so protection is not just visual

Validation

npx vitest run tests/app.headerWalletIndependence.test.js

 npx vitest run

Fixes #203