### PR TITLE
Show order fee token on cleanup page

### DIFF
--- a/css/components/cleanup.css
+++ b/css/components/cleanup.css
@@ -48,6 +48,23 @@
   color: var(--text-primary);
 }
 
+.cleanup-reward-token {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  vertical-align: middle;
+}
+
+.cleanup-reward-token .token-icon.small {
+  width: 22px;
+  height: 22px;
+  flex: 0 0 auto;
+}
+
+.cleanup-reward-token .token-icon-fallback {
+  font-size: 0.7rem;
+}
+
 #cleanup-button {
   width: 100%;
   max-width: 300px;

--- a/js/components/Cleanup.js
+++ b/js/components/Cleanup.js
@@ -2,7 +2,7 @@ import { ethers } from 'ethers';
 import { BaseComponent } from './BaseComponent.js';
 import { createLogger } from '../services/LogService.js';
 import { handleTransactionError } from '../utils/ui.js';
-import { contractService } from '../services/ContractService.js';
+import { getFallbackIconData } from '../utils/tokenIcons.js';
 
 export class Cleanup extends BaseComponent {
     constructor(containerId) {
@@ -46,6 +46,75 @@ export class Cleanup extends BaseComponent {
         this.warn('Wallet picker is not available from Cleanup');
         this.showError('Use the header Connect Wallet button to choose a wallet.');
         return false;
+    }
+
+    getOrderCleanupFee(order) {
+        if (!order?.feeToken || order.orderCreationFee === null || order.orderCreationFee === undefined) {
+            return null;
+        }
+
+        return {
+            feeToken: order.feeToken,
+            feeAmount: ethers.BigNumber.from(order.orderCreationFee)
+        };
+    }
+
+    getFallbackTokenSymbol(tokenAddress) {
+        if (!tokenAddress || typeof tokenAddress !== 'string') {
+            return 'Fee token';
+        }
+        return `${tokenAddress.slice(0, 6)}...${tokenAddress.slice(-4)}`;
+    }
+
+    setCurrentRewardText(element, text) {
+        if (!element) return;
+        element.replaceChildren();
+        element.textContent = text;
+        element.removeAttribute('aria-label');
+    }
+
+    createCleanupRewardIcon(tokenInfo, tokenAddress, symbol) {
+        const icon = document.createElement('span');
+        icon.className = 'token-icon small cleanup-reward-icon';
+        icon.setAttribute('aria-hidden', 'true');
+
+        const fallbackData = getFallbackIconData(tokenAddress, symbol);
+        const fallback = document.createElement('span');
+        fallback.className = 'token-icon-fallback small';
+        fallback.style.background = fallbackData.backgroundColor;
+        fallback.textContent = fallbackData.text;
+
+        if (tokenInfo?.iconUrl && tokenInfo.iconUrl !== 'fallback') {
+            const image = document.createElement('img');
+            image.src = tokenInfo.iconUrl;
+            image.alt = '';
+            image.className = 'token-icon-image';
+            fallback.style.display = 'none';
+            image.addEventListener('error', () => {
+                image.style.display = 'none';
+                fallback.style.display = 'flex';
+            });
+            icon.append(image, fallback);
+            return icon;
+        }
+
+        icon.append(fallback);
+        return icon;
+    }
+
+    renderCurrentReward(element, { formattedAmount, tokenInfo, feeToken }) {
+        if (!element) return;
+
+        const symbol = tokenInfo?.symbol || this.getFallbackTokenSymbol(feeToken);
+        const wrapper = document.createElement('span');
+        wrapper.className = 'cleanup-reward-token';
+        wrapper.append(
+            this.createCleanupRewardIcon(tokenInfo, feeToken, symbol),
+            this.createElement('span', 'cleanup-reward-amount', `${formattedAmount} ${symbol}`)
+        );
+
+        element.replaceChildren(wrapper);
+        element.setAttribute('aria-label', `${formattedAmount} ${symbol}`);
     }
 
     async initialize(readOnlyMode = true) {
@@ -303,33 +372,46 @@ export class Cleanup extends BaseComponent {
             // Display reward for next cleanup
             if (elements.currentReward && nextOrderToClean) {
                 try {
-                    // Use HTTP RPC for fee config to avoid WebSocket timeout issues
-                    const { feeToken, feeAmount } = await contractService.getFeeConfig();
+                    const cleanupFee = this.getOrderCleanupFee(nextOrderToClean);
+                    if (!cleanupFee) {
+                        throw new Error(`Missing cleanup fee details for order ${nextOrderToClean.id}`);
+                    }
 
-                    this.debug('Fee info from contract:', { feeToken, feeAmount: feeAmount.toString() });
+                    const { feeToken, feeAmount } = cleanupFee;
+                    this.debug('Fee info from order:', {
+                        orderId: nextOrderToClean.id,
+                        feeToken,
+                        feeAmount: feeAmount.toString()
+                    });
 
                     const tokenInfo = await this.webSocket.getTokenInfo(feeToken);
+                    const decimals = Number.isInteger(tokenInfo?.decimals) ? tokenInfo.decimals : 18;
                     
                     // Format with proper decimals and round to 6 decimal places
                     const formattedAmount = parseFloat(
-                        ethers.utils.formatUnits(feeAmount, tokenInfo.decimals)
+                        ethers.utils.formatUnits(feeAmount, decimals)
                     ).toFixed(6);
 
-                    elements.currentReward.textContent = `${formattedAmount} ${tokenInfo.symbol}`;
+                    this.renderCurrentReward(elements.currentReward, {
+                        formattedAmount,
+                        tokenInfo,
+                        feeToken
+                    });
 
                     this.debug('Reward formatting:', {
+                        orderId: nextOrderToClean.id,
                         feeToken,
                         feeAmount: feeAmount.toString(),
-                        decimals: tokenInfo.decimals,
+                        decimals,
                         formatted: formattedAmount,
-                        symbol: tokenInfo.symbol
+                        symbol: tokenInfo?.symbol
                     });
                 } catch (error) {
                     this.debug('Error formatting reward:', error);
-                    elements.currentReward.textContent = 'Error getting reward amount';
+                    this.setCurrentRewardText(elements.currentReward, 'Error getting reward amount');
                 }
             } else if (elements.currentReward) {
-                elements.currentReward.textContent = 'No orders to clean';
+                this.setCurrentRewardText(elements.currentReward, 'No orders to clean');
             }
 
             if (elements.cleanupButton) {

--- a/tests/cleanup.orderFeeToken.test.js
+++ b/tests/cleanup.orderFeeToken.test.js
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ethers } from 'ethers';
+import { Cleanup } from '../js/components/Cleanup.js';
+import { contractService } from '../js/services/ContractService.js';
+
+const OLD_FEE_TOKEN = '0x1111111111111111111111111111111111111111';
+const NEW_FEE_TOKEN = '0x2222222222222222222222222222222222222222';
+
+function createContext() {
+    return {
+        getWallet: () => ({
+            isWalletConnected: () => false,
+            addListener: () => {}
+        }),
+        showError: vi.fn(),
+        showSuccess: vi.fn(),
+        showWarning: vi.fn(),
+        showInfo: vi.fn()
+    };
+}
+
+afterEach(() => {
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+});
+
+describe('Cleanup order fee token display', () => {
+    it('shows the fee token from the next cleanup order instead of the current fee config', async () => {
+        document.body.innerHTML = `
+            <div id="cleanup-container"></div>
+            <span id="current-reward">Loading...</span>
+            <span id="cleanup-ready">Loading...</span>
+            <button id="cleanup-button"></button>
+        `;
+
+        const getFeeConfigSpy = vi
+            .spyOn(contractService, 'getFeeConfig')
+            .mockRejectedValue(new Error('current fee config should not be used'));
+
+        const getTokenInfo = vi.fn(async (address) => {
+            if (address === OLD_FEE_TOKEN) {
+                return {
+                    symbol: 'OLD',
+                    decimals: 6,
+                    iconUrl: 'img/token-logos/old-fee-token.png'
+                };
+            }
+            return {
+                symbol: 'NEW',
+                decimals: 18,
+                iconUrl: 'img/token-logos/new-fee-token.png'
+            };
+        });
+
+        const component = new Cleanup();
+        component.setContext(createContext());
+        component.webSocket = {
+            contract: {},
+            getOrders: vi.fn(() => [
+                {
+                    id: 9,
+                    timings: { graceEndsAt: 100 },
+                    feeToken: NEW_FEE_TOKEN,
+                    orderCreationFee: ethers.utils.parseEther('1')
+                },
+                {
+                    id: 3,
+                    timings: { graceEndsAt: 100 },
+                    feeToken: OLD_FEE_TOKEN,
+                    orderCreationFee: ethers.BigNumber.from('2500000')
+                }
+            ]),
+            ensureChainTimeInitialized: vi.fn(async () => {}),
+            getCurrentTimestamp: vi.fn(() => 200),
+            getTokenInfo
+        };
+
+        await component.checkCleanupOpportunities();
+
+        expect(getFeeConfigSpy).not.toHaveBeenCalled();
+        expect(getTokenInfo).toHaveBeenCalledTimes(1);
+        expect(getTokenInfo).toHaveBeenCalledWith(OLD_FEE_TOKEN);
+        expect(document.getElementById('cleanup-ready').textContent).toBe('2');
+        expect(document.querySelector('.cleanup-reward-amount').textContent).toBe('2.500000 OLD');
+        expect(
+            document.querySelector('.cleanup-reward-icon img').getAttribute('src')
+        ).toBe('img/token-logos/old-fee-token.png');
+        expect(document.getElementById('current-reward').getAttribute('aria-label')).toBe('2.500000 OLD');
+    });
+});


### PR DESCRIPTION
## Summary
- render the Cleanup page reward from the next eligible order's stored `feeToken` and `orderCreationFee`
- show the matching token icon/symbol instead of reading the current fee config
- add regression coverage for fee-token changes between order creation and cleanup

Closes #216.

## Validation
- `npx vitest run tests/cleanup.orderFeeToken.test.js`
- `npm test` (46/46 files, 190/190 tests)