### PR TITLE
Wallet badge: icon + address, glass dropdowns (#220)

### DIFF
--- a/css/components/wallet.css
+++ b/css/components/wallet.css
@@ -284,14 +284,48 @@
   font-weight: 800;
 }
 
-.wallet-selection-icon img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
+.wallet-selection-icon:has(> img:not([hidden])) {
+  overflow: visible;
+  border-radius: 0;
+  background: transparent;
 }
 
-.wallet-selection-icon img[hidden] {
+.wallet-selection-icon img {
+  width: 30px;
+  height: 30px;
+  object-fit: contain;
+}
+
+.wallet-selection-icon img[hidden],
+.wallet-info-icon img[hidden] {
   display: none;
+}
+
+.wallet-info-icon {
+  width: 16px;
+  height: 16px;
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  border-radius: 50%;
+  background: rgba(75, 107, 251, 0.16);
+  color: #4b6bfb;
+  font-size: 8px;
+  font-weight: 800;
+}
+
+.wallet-info-icon:has(> img:not([hidden])) {
+  overflow: visible;
+  border-radius: 0;
+  background: transparent;
+}
+
+.wallet-info-icon img {
+  width: 16px;
+  height: 16px;
+  object-fit: contain;
 }
 
 .wallet-selection-copy {
@@ -326,8 +360,9 @@
   justify-content: flex-start;
   gap: 6px;
   background: rgba(255, 255, 255, 0.24);
-  padding: 8px 12px;
+  padding: 8px 12px 8px 22px;
   min-width: 196px;
+  max-width: 260px;
   min-height: 42px;
   border-radius: 12px;
   border: 1px solid var(--border-color);

--- a/css/components/wallet.css
+++ b/css/components/wallet.css
@@ -86,7 +86,7 @@
   position: absolute;
   top: calc(100% + 4px);
   right: 0;
-  background: var(--dropdown-glass-bg);
+  background: var(--background-secondary);
   border: 1px solid var(--border-color);
   border-radius: 12px;
   padding: 4px;
@@ -148,7 +148,7 @@
 
 .network-option:hover,
 .network-option.active {
-  background: var(--dropdown-glass-hover);
+  background: var(--background-hover);
 }
 
 .network-dropdown[data-network-status="connected"] .network-option:hover,
@@ -535,7 +535,7 @@
 }
 
 .wallet-popup-close:hover {
-  background: var(--background-hover);
+  background: var(--dropdown-glass-hover);
   border-color: var(--border-color);
   color: var(--text-primary);
 }
@@ -610,28 +610,14 @@
 }
 
 [data-theme="dark"] .wallet-info-popup-content {
-  background: var(--dropdown-glass-bg);
   border-color: rgba(148, 163, 184, 0.32);
   box-shadow: 0 18px 42px rgba(0, 0, 0, 0.46);
 }
 
-[data-theme="dark"] .wallet-popup-close {
-  background: rgba(30, 41, 59, 0.9);
-  border-color: rgba(148, 163, 184, 0.32);
-}
-
-[data-theme="dark"] .wallet-popup-address-box {
-  background: rgba(30, 41, 59, 0.8);
-  border-color: rgba(148, 163, 184, 0.32);
-}
-
+[data-theme="dark"] .wallet-popup-close,
+[data-theme="dark"] .wallet-popup-address-box,
 [data-theme="dark"] .copy-icon-button {
-  background: rgba(30, 41, 59, 0.88);
   border-color: rgba(148, 163, 184, 0.32);
-}
-
-[data-theme="dark"] .copy-icon-button:hover {
-  background: rgba(51, 65, 85, 0.96);
 }
 
 [data-theme="dark"] .disconnect-button {

--- a/css/components/wallet.css
+++ b/css/components/wallet.css
@@ -86,7 +86,7 @@
   position: absolute;
   top: calc(100% + 4px);
   right: 0;
-  background: var(--background-secondary);
+  background: var(--dropdown-glass-bg);
   border: 1px solid var(--border-color);
   border-radius: 12px;
   padding: 4px;
@@ -148,7 +148,7 @@
 
 .network-option:hover,
 .network-option.active {
-  background: var(--background-hover);
+  background: var(--dropdown-glass-hover);
 }
 
 .network-dropdown[data-network-status="connected"] .network-option:hover,
@@ -233,7 +233,7 @@
   right: 0;
   width: min(320px, calc(100vw - 24px));
   padding: 8px;
-  background: var(--background-secondary);
+  background: var(--dropdown-glass-bg);
   border: 1px solid var(--border-color);
   border-radius: 12px;
   box-shadow: 0 16px 34px rgba(0, 0, 0, 0.18);
@@ -266,7 +266,7 @@
 
 .wallet-selection-option:hover,
 .wallet-selection-option:focus-visible {
-  background: var(--background-hover);
+  background: var(--dropdown-glass-hover);
 }
 
 .wallet-selection-icon {
@@ -290,8 +290,7 @@
   object-fit: cover;
 }
 
-.wallet-selection-icon img[hidden],
-.wallet-info-icon img[hidden] {
+.wallet-selection-icon img[hidden] {
   display: none;
 }
 
@@ -335,38 +334,6 @@
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.14);
   cursor: pointer;
   transition: background-color 150ms ease, border-color 150ms ease, transform 50ms ease;
-}
-
-.wallet-info-icon {
-  width: 24px;
-  height: 24px;
-  flex: 0 0 auto;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  overflow: hidden;
-  border-radius: 7px;
-  background: rgba(75, 107, 251, 0.16);
-  color: #4b6bfb;
-  font-size: 10px;
-  font-weight: 800;
-}
-
-.wallet-info-icon img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-}
-
-.wallet-info-name {
-  min-width: 0;
-  max-width: 82px;
-  overflow: hidden;
-  color: var(--text-primary);
-  font-size: 14px;
-  font-weight: 650;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .wallet-info:hover {
@@ -528,7 +495,7 @@
 .wallet-info-popup-content {
   padding: 14px;
   position: relative;
-  background: rgba(248, 251, 255, 0.95);
+  background: var(--dropdown-glass-bg);
   border: 1px solid var(--border-color);
   border-radius: 12px;
   box-shadow: 0 14px 34px rgba(15, 23, 42, 0.28);
@@ -553,7 +520,7 @@
   padding: 0;
   border-radius: 50%;
   border: 1px solid var(--border-color);
-  background: rgba(255, 255, 255, 0.82);
+  background: var(--dropdown-glass-hover);
   color: var(--text-secondary);
   font-size: 0;
   line-height: 1;
@@ -596,12 +563,12 @@
   border: 1px solid var(--border-color);
   border-radius: 8px;
   padding: 10px 12px;
-  background: rgba(255, 255, 255, 0.84);
+  background: var(--dropdown-glass-hover);
 }
 
 .copy-icon-button {
   border: 1px solid var(--border-color);
-  background: rgba(255, 255, 255, 0.9);
+  background: var(--dropdown-glass-bg);
   border-radius: 8px;
   padding: 8px 10px;
   color: var(--text-primary);
@@ -609,7 +576,7 @@
 }
 
 .copy-icon-button:hover {
-  background: rgba(255, 255, 255, 0.98);
+  background: var(--dropdown-glass-hover);
 }
 
 .wallet-popup-actions {
@@ -643,7 +610,7 @@
 }
 
 [data-theme="dark"] .wallet-info-popup-content {
-  background: rgba(17, 24, 39, 0.95);
+  background: var(--dropdown-glass-bg);
   border-color: rgba(148, 163, 184, 0.32);
   box-shadow: 0 18px 42px rgba(0, 0, 0, 0.46);
 }

--- a/css/styles.css
+++ b/css/styles.css
@@ -988,9 +988,9 @@ input {
 .header-right .wallet-info {
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   gap: 6px;
-  padding: 8px 12px;
+  padding: 8px 12px 8px 22px;
   min-width: 196px;
   min-height: 42px;
   border-radius: 12px;

--- a/css/styles.css
+++ b/css/styles.css
@@ -63,6 +63,9 @@
   --network-button-disconnected-border: #b8c0cb;
   --network-button-disconnected-hover: #d7dde5;
   --network-button-disconnected-text: #1a1a1a;
+  /* Dropdown glass: 50% less transparent than --background-secondary / --background-hover */
+  --dropdown-glass-bg: rgba(255, 255, 255, 0.90);
+  --dropdown-glass-hover: rgba(255, 255, 255, 0.95);
 }
 
 [data-theme="dark"] {
@@ -120,6 +123,9 @@
   --network-button-disconnected-border: #747474;
   --network-button-disconnected-hover: #545454;
   --network-button-disconnected-text: #ffffff;
+  /* Dropdown glass: 50% less transparent than --background-secondary / --background-hover */
+  --dropdown-glass-bg: rgba(24, 30, 40, 0.81);
+  --dropdown-glass-hover: rgba(35, 42, 56, 0.87);
 }
 
 /* Base styles */
@@ -911,7 +917,11 @@ input {
 }
 
 /* Update dropdown backgrounds */
-.network-dropdown,
+.network-dropdown {
+  background: var(--dropdown-glass-bg);
+  border-color: var(--border-color);
+}
+
 .token-modal-content {
   background: var(--bg-secondary);
   border-color: var(--border-color);

--- a/css/styles.css
+++ b/css/styles.css
@@ -63,7 +63,6 @@
   --network-button-disconnected-border: #b8c0cb;
   --network-button-disconnected-hover: #d7dde5;
   --network-button-disconnected-text: #1a1a1a;
-  /* Dropdown glass: 50% less transparent than --background-secondary / --background-hover */
   --dropdown-glass-bg: rgba(255, 255, 255, 0.90);
   --dropdown-glass-hover: rgba(255, 255, 255, 0.95);
 }
@@ -123,7 +122,6 @@
   --network-button-disconnected-border: #747474;
   --network-button-disconnected-hover: #545454;
   --network-button-disconnected-text: #ffffff;
-  /* Dropdown glass: 50% less transparent than --background-secondary / --background-hover */
   --dropdown-glass-bg: rgba(24, 30, 40, 0.81);
   --dropdown-glass-hover: rgba(35, 42, 56, 0.87);
 }
@@ -917,11 +915,7 @@ input {
 }
 
 /* Update dropdown backgrounds */
-.network-dropdown {
-  background: var(--dropdown-glass-bg);
-  border-color: var(--border-color);
-}
-
+.network-dropdown,
 .token-modal-content {
   background: var(--bg-secondary);
   border-color: var(--border-color);

--- a/js/components/WalletUI.js
+++ b/js/components/WalletUI.js
@@ -533,8 +533,11 @@ export class WalletUI extends BaseComponent {
     }
 
     renderConnectedWalletInfo(shortAddress) {
+        const { name, icon } = walletManager.getSelectedWalletInfo();
+        const walletIcon = this.createWalletIconElement({ name, icon }, 'wallet-info-icon');
+
         this.accountAddress.textContent = shortAddress;
-        this.walletInfo.replaceChildren(this.accountAddress);
+        this.walletInfo.replaceChildren(walletIcon, this.accountAddress);
     }
 
     showConnectButton() {

--- a/js/components/WalletUI.js
+++ b/js/components/WalletUI.js
@@ -533,12 +533,6 @@ export class WalletUI extends BaseComponent {
     }
 
     renderConnectedWalletInfo(shortAddress) {
-        if (!this.accountAddress) {
-            this.accountAddress = document.createElement('span');
-            this.accountAddress.id = 'accountAddress';
-            this.accountAddress.className = 'account-address';
-        }
-
         this.accountAddress.textContent = shortAddress;
         this.walletInfo.replaceChildren(this.accountAddress);
     }

--- a/js/components/WalletUI.js
+++ b/js/components/WalletUI.js
@@ -23,8 +23,6 @@ export class WalletUI extends BaseComponent {
         this.popupAccount = null;
         this.walletPopup = null;
         this.walletSelectionMenu = null;
-        this.connectedWalletIcon = null;
-        this.connectedWalletName = null;
         
         this.debug('Constructor completed (no side effects)');
     }
@@ -535,28 +533,14 @@ export class WalletUI extends BaseComponent {
     }
 
     renderConnectedWalletInfo(shortAddress) {
-        const selectedWallet = walletManager.getSelectedWalletInfo?.() || {};
-        const walletName = selectedWallet.name || 'Wallet';
+        if (!this.accountAddress) {
+            this.accountAddress = document.createElement('span');
+            this.accountAddress.id = 'accountAddress';
+            this.accountAddress.className = 'account-address';
+        }
 
-        this.connectedWalletIcon = this.createWalletIconElement({
-            name: walletName,
-            icon: selectedWallet.icon || ''
-        }, 'wallet-info-icon');
-
-        this.connectedWalletName = document.createElement('span');
-        this.connectedWalletName.className = 'wallet-info-name';
-        this.connectedWalletName.textContent = walletName;
-
-        this.accountAddress = document.createElement('span');
-        this.accountAddress.id = 'accountAddress';
-        this.accountAddress.className = 'account-address';
         this.accountAddress.textContent = shortAddress;
-
-        this.walletInfo.replaceChildren(
-            this.connectedWalletIcon,
-            this.connectedWalletName,
-            this.accountAddress
-        );
+        this.walletInfo.replaceChildren(this.accountAddress);
     }
 
     showConnectButton() {

--- a/tests/walletUI.selectionMenu.test.js
+++ b/tests/walletUI.selectionMenu.test.js
@@ -57,4 +57,24 @@ describe('WalletUI wallet selection menu', () => {
         expect(image?.getAttribute('src')).toContain('data:image/svg+xml');
         expect(option.querySelector('.wallet-selection-name')?.textContent).toBe('MetaMask');
     });
+
+    it('shows only truncated address in connected wallet badge', () => {
+        document.body.innerHTML = `
+            <div id="wallet-container"></div>
+            <button id="walletConnect">Connect Wallet</button>
+            <div id="walletInfo" class="wallet-info">
+                <span id="accountAddress" class="account-address"></span>
+            </div>
+            <div id="wallet-popup-container"></div>
+        `;
+
+        ui = new WalletUI();
+        ui.initializeElements();
+        ui.renderConnectedWalletInfo('0x6587...2361');
+
+        expect(ui.walletInfo.querySelector('.wallet-info-icon')).toBeNull();
+        expect(ui.walletInfo.querySelector('.wallet-info-name')).toBeNull();
+        expect(ui.walletInfo.children).toHaveLength(1);
+        expect(ui.accountAddress.textContent).toBe('0x6587...2361');
+    });
 });

--- a/tests/walletUI.selectionMenu.test.js
+++ b/tests/walletUI.selectionMenu.test.js
@@ -72,9 +72,7 @@ describe('WalletUI wallet selection menu', () => {
         ui.initializeElements();
         ui.renderConnectedWalletInfo('0x6587...2361');
 
-        expect(ui.walletInfo.querySelector('.wallet-info-icon')).toBeNull();
-        expect(ui.walletInfo.querySelector('.wallet-info-name')).toBeNull();
         expect(ui.walletInfo.children).toHaveLength(1);
-        expect(ui.accountAddress.textContent).toBe('0x6587...2361');
+        expect(ui.walletInfo.textContent).toBe('0x6587...2361');
     });
 });

--- a/tests/walletUI.selectionMenu.test.js
+++ b/tests/walletUI.selectionMenu.test.js
@@ -1,5 +1,6 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { WalletUI } from '../js/components/WalletUI.js';
+import { walletManager } from '../js/services/WalletManager.js';
 
 let ui = null;
 
@@ -58,7 +59,7 @@ describe('WalletUI wallet selection menu', () => {
         expect(option.querySelector('.wallet-selection-name')?.textContent).toBe('MetaMask');
     });
 
-    it('shows only truncated address in connected wallet badge', () => {
+    it('shows wallet icon and truncated address without wallet name in connected badge', () => {
         document.body.innerHTML = `
             <div id="wallet-container"></div>
             <button id="walletConnect">Connect Wallet</button>
@@ -68,11 +69,19 @@ describe('WalletUI wallet selection menu', () => {
             <div id="wallet-popup-container"></div>
         `;
 
+        vi.spyOn(walletManager, 'getSelectedWalletInfo').mockReturnValue({
+            name: 'Trust Wallet',
+            icon: "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg'/>",
+        });
+
         ui = new WalletUI();
         ui.initializeElements();
         ui.renderConnectedWalletInfo('0x6587...2361');
 
-        expect(ui.walletInfo.children).toHaveLength(1);
-        expect(ui.walletInfo.textContent).toBe('0x6587...2361');
+        expect(ui.walletInfo.querySelector('.wallet-info-name')).toBeNull();
+        expect(ui.walletInfo.querySelector('.wallet-info-icon img')?.getAttribute('src')).toContain(
+            'data:image/svg+xml'
+        );
+        expect(ui.accountAddress.textContent).toBe('0x6587...2361');
     });
 });


### PR DESCRIPTION
## Summary

Closes #220

Aligns the connected wallet header and wallet menus with other Liberdus repos: show provider icon and truncated address (no wallet name label), with shared glass dropdown styling and cleaner wallet logos.

## What changed

- **`WalletUI.js`**: Connected badge renders wallet icon + `#accountAddress` only (removes provider name from the chip).
- **`styles.css`**: Adds `--dropdown-glass-bg` / `--dropdown-glass-hover` (light + dark) for tunable menu/popup opacity.
- **`wallet.css`**:
  - Select Wallet menu and connected-wallet popup use glass tokens; popup keeps original layout (address row, copy, full-width disconnect).
  - Wallet logos render without the blue chip when an image loads; `object-fit: contain` avoids clipping (e.g. MetaMask fox).
  - Header chip left padding (`22px`) matches network selector logo inset.
- **Tests**: Connected badge has icon + address and no `.wallet-info-name`.
-
BEFORE:
<img width="585" height="356" alt="image" src="https://github.com/user-attachments/assets/bf6c117a-a86a-4bd5-b1a4-0edd4f9fe2e2" />
<img width="669" height="99" alt="image" src="https://github.com/user-attachments/assets/b881bc0f-7f28-47ec-a7cf-7315a9a0706e" />

AFTER:
<img width="585" height="356" alt="image" src="https://github.com/user-attachments/assets/a19d00e2-0a98-40f2-a0d8-839c2de8832b" />
<img width="573" height="101" alt="image" src="https://github.com/user-attachments/assets/7979550e-c21b-4a1b-a700-fc1d6ba3c4f6" />

## Test plan

- [x] Connect a wallet — header shows provider icon + `0x1234...5678` (no "MetaMask" / "Trust Wallet" text).
- [x] Icon aligns with BNB Chain logo on the network button; logo has no extra circular background when loaded.
- [x] **Connect Wallet** menu — logos display fully without blue tiles or bottom clipping.
- [x] Click address chip — popup works (copy, disconnect); glass readability is acceptable in light/dark.
- [x] Tune opacity via `--dropdown-glass-*` in `styles.css` if needed.
- [x] `npm test`