### PR TITLE
Bump liberdus-wallet-module to 6da2af4

### DIFF
--- a/.github/workflows/e2e-pr.yml
+++ b/.github/workflows/e2e-pr.yml
@@ -21,7 +21,7 @@ jobs:
     if: github.event.pull_request.draft == false
     uses: WhaleSwap-org/WhaleSwap-E2E/.github/workflows/manual-e2e.yml@main
     with:
-      e2e_ref: wallet-module-import
+      e2e_ref: main
       contract_ref: main
       ui_repository: ${{ github.event.pull_request.head.repo.full_name }}
       ui_ref: ${{ github.event.pull_request.head.sha }}

--- a/tests/walletManager.providerMode.test.js
+++ b/tests/walletManager.providerMode.test.js
@@ -74,7 +74,7 @@ describe('WalletManager provider initialization', () => {
             removeListener: vi.fn(),
         };
 
-        localStorage.setItem('whaleswap-ui:wallet-session', JSON.stringify({ walletId: 'legacy:globalthis' }));
+        localStorage.setItem('whaleswap-ui:wallet-session', JSON.stringify({ walletId: 'legacy:default' }));
         window.ethereum = injectedProvider;
 
         const { WalletManager } = await import('../js/services/WalletManager.js');


### PR DESCRIPTION
## Summary
Bumps `vendor/liberdus-wallet-module` to `6da2af4`, the latest shared wallet module commit.

This brings in the wallet discovery and session fixes from the module: connected wallet state now stays aligned when a late EIP-6963 announcement replaces a legacy injected provider, and read-only discovery no longer probes browser window aliases such as `self`, `top`, or `parent` as wallet namespaces.

Also updates one saved-session fixture from `legacy:globalthis` to `legacy:default`, matching the module's corrected handling of browser aliases.

This PR's E2E workflow now uses WhaleSwap-E2E `main`. Merge WhaleSwap-E2E PR #10 first, then merge this UI PR after its tests pass against that main E2E workflow.

## Why
This app gets its wallet behavior through the shared wallet module. Updating the submodule keeps the app on the fixed connection/discovery behavior, avoiding stale provider references after replacement and unnecessary default-provider probes during discovery.

The old alias-based wallet id, `legacy:globalthis`, came from browser window alias discovery. The bumped module intentionally stops exposing those aliases as separate wallets, so the default injected wallet is now represented canonically as `legacy:default`.

## E2E Follow-Up
WhaleSwap-E2E PR #10 updates the shared helper to select `[data-wallet-id="legacy:default"]`.

This PR's `.github/workflows/e2e-pr.yml` now passes `e2e_ref: main`, so the UI PR check is intentionally facing the merged E2E workflow rather than a temporary E2E branch. Once E2E PR #10 is merged and this PR's checks are green, this UI PR can be merged.

## Validation
- `npm test`
- `npx tsc --noEmit --skipLibCheck --module NodeNext --moduleResolution NodeNext --target ES2022 tests/helpers/uiReady.ts` in `WhaleSwap-E2E`
- `git diff --check` for the UI E2E workflow update